### PR TITLE
Fix ApiService to include Authorization header on all requests

### DIFF
--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -9,13 +9,16 @@ export class ApiService {
   }
 
   private getHeaders(): HeadersInit {
-    const token =
-      typeof window !== "undefined"
-        ? (JSON.parse(localStorage.getItem("token") ?? "null") as string | null)
-        : null;
+    let token: string | null = null;
+    if (typeof window !== "undefined") {
+      try {
+        token = JSON.parse(localStorage.getItem("token") ?? "null") as string | null;
+      } catch {
+        token = null;
+      }
+    }
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "Access-Control-Allow-Origin": "*",
     };
     if (token) headers["Authorization"] = token;
     return headers;

--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -3,14 +3,22 @@ import { ApplicationError } from "@/types/error";
 
 export class ApiService {
   private baseURL: string;
-  private defaultHeaders: HeadersInit;
 
   constructor() {
     this.baseURL = getApiDomain();
-    this.defaultHeaders = {
+  }
+
+  private getHeaders(): HeadersInit {
+    const token =
+      typeof window !== "undefined"
+        ? (JSON.parse(localStorage.getItem("token") ?? "null") as string | null)
+        : null;
+    const headers: Record<string, string> = {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
     };
+    if (token) headers["Authorization"] = token;
+    return headers;
   }
 
   /**
@@ -64,7 +72,7 @@ export class ApiService {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, {
       method: "GET",
-      headers: this.defaultHeaders,
+      headers: this.getHeaders(),
     });
     return this.processResponse<T>(
       res,
@@ -82,7 +90,7 @@ export class ApiService {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, {
       method: "POST",
-      headers: this.defaultHeaders,
+      headers: this.getHeaders(),
       body: JSON.stringify(data),
     });
     return this.processResponse<T>(
@@ -101,7 +109,7 @@ export class ApiService {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, {
       method: "PUT",
-      headers: this.defaultHeaders,
+      headers: this.getHeaders(),
       body: JSON.stringify(data),
     });
     return this.processResponse<T>(
@@ -119,7 +127,7 @@ export class ApiService {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, {
       method: "DELETE",
-      headers: this.defaultHeaders,
+      headers: this.getHeaders(),
     });
     return this.processResponse<T>(
       res,


### PR DESCRIPTION
## Summary
- ApiService now reads the token from localStorage on every request
- Attaches it as an Authorization header when present
- Fixes 401 errors on protected endpoints like /products/lookup and /products/search that were previously called without auth