### PR TITLE
Tingting/issue 9 12 calorie dashboard

### DIFF
--- a/app/components/VirtualPantryAppShell.tsx
+++ b/app/components/VirtualPantryAppShell.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+import { App, Avatar, ConfigProvider, theme as antdTheme } from "antd";
+import {
+  DashboardOutlined,
+  HomeOutlined,
+  InboxOutlined,
+  LogoutOutlined,
+  ReadOutlined,
+} from "@ant-design/icons";
+import useLocalStorage from "@/hooks/useLocalStorage";
+import type { HouseholdWithRole } from "@/types/household";
+import styles from "@/styles/households.module.css";
+
+export type VirtualPantryNav = "dashboard" | "households" | "pantry" | "recipes";
+
+interface VirtualPantryAppShellProps {
+  activeNav: VirtualPantryNav;
+  children: React.ReactNode;
+}
+
+export function VirtualPantryAppShell({ activeNav, children }: VirtualPantryAppShellProps) {
+  const router = useRouter();
+  const { message } = App.useApp();
+  const { clear: clearToken } = useLocalStorage<string>("token", "");
+  const { clear: clearUsername } = useLocalStorage<string>("username", "");
+  const { value: households } = useLocalStorage<HouseholdWithRole[]>("households", []);
+  const { value: selectedHouseholdId, set: setSelectedHouseholdId } = useLocalStorage<
+    number | null
+  >("selectedHouseholdId", null);
+  const { value: username } = useLocalStorage<string>("username", "");
+
+  const handleSidebarPantry = () => {
+    if (households.length === 0) {
+      message.info("Create or join a household first, then open Pantry.");
+      return;
+    }
+    const id =
+      selectedHouseholdId !== null &&
+      households.some((h) => h.householdId === selectedHouseholdId)
+        ? selectedHouseholdId
+        : households[0].householdId;
+    setSelectedHouseholdId(id);
+    router.push("/stats");
+  };
+
+  const handleLogout = () => {
+    clearToken();
+    clearUsername();
+    router.push("/login");
+  };
+
+  const userLabel = username?.trim() ? username.trim() : "@unknown";
+  const userInitial = userLabel.charAt(0).toUpperCase();
+
+  const navBtn = (nav: VirtualPantryNav) =>
+    `${styles.menuItem} ${activeNav === nav ? styles.menuItemActive : ""}`;
+
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: antdTheme.defaultAlgorithm,
+        token: {
+          colorPrimary: "#1f7a3f",
+          colorText: "#182418",
+          colorTextSecondary: "#566556",
+          colorBgBase: "#f7f8ef",
+          colorBgContainer: "#ffffff",
+          colorBorder: "#dce4d0",
+          borderRadius: 10,
+        },
+        components: {
+          Input: {
+            colorBgContainer: "#ffffff",
+            colorText: "#1d2a1d",
+            colorBorder: "#d8dfca",
+          },
+        },
+      }}
+    >
+      <div className={styles.layout}>
+        <aside className={styles.sidebar}>
+          <div>
+            <div className={styles.brand}>Virtual Pantry</div>
+            <div className={styles.brandTagline}>The Organic Atelier</div>
+          </div>
+          <nav className={styles.menu}>
+            <button
+              type="button"
+              className={navBtn("dashboard")}
+              onClick={() => router.push("/users")}
+            >
+              <DashboardOutlined className={styles.menuIcon} />
+              <span className={styles.menuText}>Dashboard</span>
+            </button>
+            <button type="button" className={navBtn("households")} onClick={() => router.push("/households")}>
+              <HomeOutlined className={styles.menuIcon} />
+              <span className={styles.menuText}>Households</span>
+            </button>
+            <button type="button" className={navBtn("pantry")} onClick={handleSidebarPantry}>
+              <InboxOutlined className={styles.menuIcon} />
+              <span className={styles.menuText}>Pantry</span>
+            </button>
+            <button
+              type="button"
+              className={navBtn("recipes")}
+              onClick={() => message.info("Recipes are coming soon.")}
+            >
+              <ReadOutlined className={styles.menuIcon} />
+              <span className={styles.menuText}>Recipes</span>
+            </button>
+          </nav>
+
+          <div className={styles.sidebarFooter}>
+            <button type="button" className={styles.logoutButton} onClick={handleLogout}>
+              <LogoutOutlined className={styles.menuIcon} />
+              <span className={styles.menuText}>Logout</span>
+            </button>
+          </div>
+        </aside>
+
+        <main className={styles.main}>
+          <div className={styles.topUserBar}>
+            <span className={styles.userName}>{userLabel}</span>
+            <Avatar size={64} className={styles.userAvatar}>
+              {userInitial}
+            </Avatar>
+          </div>
+          {children}
+        </main>
+      </div>
+    </ConfigProvider>
+  );
+}

--- a/app/households/page.test.tsx
+++ b/app/households/page.test.tsx
@@ -10,7 +10,9 @@ const errorMock = jest.fn();
 const warningMock = jest.fn();
 const infoMock = jest.fn();
 const setHouseholdsMock = jest.fn();
+const setSelectedHouseholdIdMock = jest.fn();
 let mockStoredHouseholds: any[] = [];
+let mockSelectedHouseholdId: number | null = null;
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
@@ -34,6 +36,13 @@ jest.mock("@/hooks/useLocalStorage", () => ({
     }
     if (key === "households") {
       return { value: mockStoredHouseholds, set: setHouseholdsMock, clear: jest.fn() };
+    }
+    if (key === "selectedHouseholdId") {
+      return {
+        value: mockSelectedHouseholdId,
+        set: setSelectedHouseholdIdMock,
+        clear: jest.fn(),
+      };
     }
     return { value: "", set: jest.fn(), clear: jest.fn() };
   },
@@ -120,15 +129,36 @@ describe("Households page", () => {
     jest.clearAllMocks();
     mockFetch.mockReset();
     mockStoredHouseholds = [];
+    mockSelectedHouseholdId = null;
   });
 
-  it("renders navigation and username from storage", () => {
+  it("renders navigation and household management", () => {
     render(<HouseholdsPage />);
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Households")).toBeInTheDocument();
     expect(screen.getByText("Pantry")).toBeInTheDocument();
     expect(screen.getByText("Recipes")).toBeInTheDocument();
     expect(screen.getByText("tingting-xu824")).toBeInTheDocument();
+    expect(screen.getByText("Household Management")).toBeInTheDocument();
+  });
+
+  it("sidebar Pantry shows info when there is no household", () => {
+    render(<HouseholdsPage />);
+    fireEvent.click(screen.getByText("Pantry").closest("button") as HTMLButtonElement);
+    expect(infoMock).toHaveBeenCalledWith(
+      "Create or join a household first, then open Pantry.",
+    );
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("sidebar Pantry navigates to calorie dashboard when a household exists", () => {
+    mockStoredHouseholds = [
+      { householdId: 7, name: "Home", inviteCode: "ABC", ownerId: 1, role: "owner" },
+    ];
+    render(<HouseholdsPage />);
+    fireEvent.click(screen.getByText("Pantry").closest("button") as HTMLButtonElement);
+    expect(setSelectedHouseholdIdMock).toHaveBeenCalledWith(7);
+    expect(pushMock).toHaveBeenCalledWith("/stats");
   });
 
   it("creates a household and stores it in local storage", async () => {
@@ -207,7 +237,7 @@ describe("Households page", () => {
     });
   });
 
-  it("opens the pantry detail route for a stored household", () => {
+  it("View Pantry opens the calorie dashboard for a stored household", () => {
     mockStoredHouseholds = [
       {
         householdId: 10,
@@ -221,7 +251,8 @@ describe("Households page", () => {
     render(<HouseholdsPage />);
 
     fireEvent.click(screen.getByRole("button", { name: /View Pantry/i }));
-    expect(pushMock).toHaveBeenCalledWith("/households/10?name=Test%20House");
+    expect(setSelectedHouseholdIdMock).toHaveBeenCalledWith(10);
+    expect(pushMock).toHaveBeenCalledWith("/stats");
   });
 
   it("shows warning for empty inputs", () => {

--- a/app/households/page.tsx
+++ b/app/households/page.tsx
@@ -10,29 +10,20 @@ import type {
 } from "@/types/household";
 import { getApiDomain } from "@/utils/domain";
 import styles from "@/styles/households.module.css";
+import { VirtualPantryAppShell } from "@/components/VirtualPantryAppShell";
 import {
   App,
-  Avatar,
   Button,
   Card,
   Col,
-  ConfigProvider,
   Input,
   Row,
   Space,
   Tag,
   Table,
-  theme as antdTheme,
   Typography,
 } from "antd";
-import {
-  DashboardOutlined,
-  ReadOutlined,
-  HomeOutlined,
-  InboxOutlined,
-  LogoutOutlined,
-  PlusCircleOutlined,
-} from "@ant-design/icons";
+import { PlusCircleOutlined } from "@ant-design/icons";
 
 const { Title, Paragraph } = Typography;
 
@@ -40,16 +31,15 @@ export default function HouseholdsPage() {
   const router = useRouter();
   const { message } = App.useApp();
 
-  const { value: token, clear: clearToken } = useLocalStorage<string>("token", "");
-  const { value: username, clear: clearUsername } = useLocalStorage<string>("username", "");
+  const { value: token } = useLocalStorage<string>("token", "");
   const {
     value: households,
     set: setHouseholds,
   } = useLocalStorage<HouseholdWithRole[]>("households", []);
-  const { set: setSelectedHouseholdId } = useLocalStorage<number | null>(
-    "selectedHouseholdId",
-    null,
-  );
+  const {
+    value: selectedHouseholdId,
+    set: setSelectedHouseholdId,
+  } = useLocalStorage<number | null>("selectedHouseholdId", null);
 
   const [createName, setCreateName] = useState("");
   const [joinCode, setJoinCode] = useState("");
@@ -168,23 +158,10 @@ export default function HouseholdsPage() {
 
   const handleOpenPantry = (household: HouseholdWithRole) => {
     setSelectedHouseholdId(household.householdId);
-    router.push(`/households/${household.householdId}?name=${encodeURIComponent(household.name)}`);
-  };
-
-  const handleViewStats = (householdId: number) => {
-    setSelectedHouseholdId(householdId);
     router.push("/stats");
   };
 
-  const handleLogout = () => {
-    clearToken();
-    clearUsername();
-    router.push("/login");
-  };
-
   const activeInvites = households.filter((household) => household.role === "owner").length;
-  const userLabel = username?.trim() ? username.trim() : "@unknown";
-  const userInitial = userLabel.charAt(0).toUpperCase();
 
   const invitationRows = ownedHouseholds.slice(0, 2).map((household) => ({
     key: household.householdId,
@@ -195,247 +172,178 @@ export default function HouseholdsPage() {
   }));
 
   return (
-    <ConfigProvider
-      theme={{
-        algorithm: antdTheme.defaultAlgorithm,
-        token: {
-          colorPrimary: "#1f7a3f",
-          colorText: "#182418",
-          colorTextSecondary: "#566556",
-          colorBgBase: "#f7f8ef",
-          colorBgContainer: "#ffffff",
-          colorBorder: "#dce4d0",
-          borderRadius: 10,
-        },
-        components: {
-          Input: {
-            colorBgContainer: "#ffffff",
-            colorText: "#1d2a1d",
-            colorBorder: "#d8dfca",
-          },
-        },
-      }}
-    >
-      <div className={styles.layout}>
-        <aside className={styles.sidebar}>
-          <div className={styles.brand}>Virtual Pantry</div>
-          <nav className={styles.menu}>
-            <button
-              type="button"
-              className={styles.menuItem}
-              onClick={() => router.push("/users")}
-            >
-              <DashboardOutlined className={styles.menuIcon} />
-              <span className={styles.menuText}>Dashboard</span>
-            </button>
-            <button
-              type="button"
-              className={`${styles.menuItem} ${styles.menuItemActive}`}
-            >
-              <HomeOutlined className={styles.menuIcon} />
-              <span className={styles.menuText}>Households</span>
-            </button>
-            <button
-              type="button"
-              className={styles.menuItem}
-              onClick={() => message.info("Open a household first, then view its pantry.")}
-            >
-              <InboxOutlined className={styles.menuIcon} />
-              <span className={styles.menuText}>Pantry</span>
-            </button>
-            <button
-              type="button"
-              className={styles.menuItem}
-              onClick={() => router.push("/stats")}
-            >
-              <ReadOutlined className={styles.menuIcon} />
-              <span className={styles.menuText}>Recipes</span>
-            </button>
-          </nav>
-
-          <div className={styles.sidebarFooter}>
-            <button type="button" className={styles.logoutButton} onClick={handleLogout}>
-              <LogoutOutlined className={styles.menuIcon} />
-              <span className={styles.menuText}>Logout</span>
-            </button>
-          </div>
-        </aside>
-
-        <main className={styles.main}>
-          <div className={styles.topUserBar}>
-            <span className={styles.userName}>{userLabel}</span>
-            <Avatar size={64} className={styles.userAvatar}>
-              {userInitial}
-            </Avatar>
-          </div>
-
-          <div className={styles.header}>
-            <div>
-              <Title level={1} className={styles.title}>Household Management</Title>
-              <Paragraph className={styles.subtitle}>
-                Organize and curate your shared pantry ecosystems.
-              </Paragraph>
-            </div>
-          </div>
-
-          <section className={styles.section}>
-            <Title level={3} className={styles.sectionTitle}>Create Household</Title>
-            <Card className={styles.joinCard}>
-              <Space direction="vertical" style={{ width: "100%" }} size="middle">
-                <Input
-                  placeholder="Enter household name"
-                  value={createName}
-                  onChange={(event) => setCreateName(event.target.value)}
-                  onPressEnter={() => void handleCreateHousehold()}
-                />
-                <Button
-                  type="primary"
-                  icon={<PlusCircleOutlined />}
-                  onClick={handleCreateHousehold}
-                  loading={creating}
-                >
-                  Create Household
-                </Button>
-              </Space>
-            </Card>
-          </section>
-
-          <Row gutter={[16, 16]} className={styles.stats}>
-            <Col xs={24} sm={12} lg={6}>
-              <Card className={styles.statCard}>
-                <div className={styles.statLabel}>Active households</div>
-                <div className={styles.statValue}>{households.length}</div>
-              </Card>
-            </Col>
-            <Col xs={24} sm={12} lg={6}>
-              <Card className={styles.statCard}>
-                <div className={styles.statLabel}>Owned households</div>
-                <div className={styles.statValue}>{ownedHouseholds.length}</div>
-              </Card>
-            </Col>
-            <Col xs={24} sm={12} lg={6}>
-              <Card className={styles.statCard}>
-                <div className={styles.statLabel}>Pantry routes ready</div>
-                <div className={styles.statValue}>{households.length}</div>
-              </Card>
-            </Col>
-            <Col xs={24} sm={12} lg={6}>
-              <Card className={styles.statCard}>
-                <div className={styles.statLabel}>Active invites</div>
-                <div className={styles.statValue}>{activeInvites}</div>
-              </Card>
-            </Col>
-          </Row>
-
-          <section className={styles.section}>
-            <Title level={3} className={styles.sectionTitle}>My Households</Title>
-            <Card className={styles.joinCard}>
-              {households.length === 0 ? (
-                <Paragraph type="secondary" style={{ margin: 0 }}>
-                  No households yet. Create one below or join with an invite code.
-                </Paragraph>
-              ) : (
-                <Row gutter={[16, 16]}>
-                  {households.map((household) => (
-                    <Col xs={24} md={12} xl={8} key={household.householdId}>
-                      <Card className={styles.householdCard}>
-                        <div className={styles.householdTopRow}>
-                          <Tag className={styles.roleTag} color={household.role === "owner" ? "green" : "blue"}>
-                            {household.role.toUpperCase()}
-                          </Tag>
-                          <span className={styles.timeHint}>recently</span>
-                        </div>
-                        <Title level={4} style={{ marginBottom: 8 }}>{household.name}</Title>
-                        <p className={styles.householdMeta}>
-                          Invite code: {household.inviteCode}
-                        </p>
-                        <Space direction="vertical" style={{ width: "100%" }}>
-                          {household.role === "owner" && (
-                            <Button
-                              onClick={() => void handleRegenerateInviteCode(household.householdId)}
-                              loading={regeneratingId === household.householdId}
-                            >
-                              Regenerate Invite Code
-                            </Button>
-                          )}
-                          <Button
-                            className={styles.outlineButton}
-                            onClick={() => handleOpenPantry(household)}
-                          >
-                            View Pantry
-                          </Button>
-                          <Button
-                            className={styles.outlineButton}
-                            onClick={() => handleViewStats(household.householdId)}
-                          >
-                            View Stats
-                          </Button>
-                        </Space>
-                      </Card>
-                    </Col>
-                  ))}
-                </Row>
-              )}
-            </Card>
-          </section>
-
-          <section className={styles.section}>
-            <Title level={3} className={styles.sectionTitle}>Join a Household</Title>
-            <Card className={styles.joinCard}>
-              <Space direction="vertical" size="middle" style={{ width: "100%" }}>
-                <div className={styles.joinHeading}>Redeem Invite Code</div>
-                <p className={styles.joinDescription}>
-                  Have an invite code from a friend or colleague? Enter it below to gain instant access
-                  to their curated pantry and start collaborating.
-                </p>
-                <div className={styles.joinRow}>
-                  <Input
-                    placeholder="Enter invite code (e.g. AB-12345)"
-                    value={joinCode}
-                    onChange={(event) => setJoinCode(event.target.value)}
-                    onPressEnter={() => void handleJoinHousehold()}
-                  />
-                  <Button type="primary" onClick={handleJoinHousehold} loading={joining}>
-                    Join Household
-                  </Button>
-                </div>
-                <div className={styles.joinInfoBox}>
-                  Codes are unique, case-sensitive, and typically expire within 7 days.
-                  If you are having trouble joining, contact the household owner for a new code.
-                </div>
-                {lastGeneratedCode && (
-                  <div className={styles.inviteBox}>Latest generated invite code: {lastGeneratedCode}</div>
-                )}
-              </Space>
-            </Card>
-          </section>
-
-          <section className={styles.section}>
-            <Title level={3} className={styles.sectionTitle}>Manage Pending Invitations</Title>
-            <Card className={styles.joinCard}>
-              <Table
-                pagination={false}
-                rowKey="key"
-                locale={{ emptyText: "No pending invitations currently." }}
-                dataSource={invitationRows}
-                columns={[
-                  { title: "Household", dataIndex: "household", key: "household" },
-                  { title: "Invite Code", dataIndex: "inviteCode", key: "inviteCode" },
-                  { title: "Created", dataIndex: "created", key: "created" },
-                  { title: "Expires", dataIndex: "expires", key: "expires" },
-                  {
-                    title: "Actions",
-                    key: "actions",
-                    render: () => (
-                      <Button size="small" className={styles.outlineButton}>Revoke</Button>
-                    ),
-                  },
-                ]}
-              />
-            </Card>
-          </section>
-        </main>
+    <VirtualPantryAppShell activeNav="households">
+      <div className={styles.header}>
+        <div>
+          <Title level={1} className={styles.title}>
+            Household Management
+          </Title>
+          <Paragraph className={styles.subtitle}>
+            Organize and curate your shared pantry ecosystems.
+          </Paragraph>
+        </div>
       </div>
-    </ConfigProvider>
+
+      <section className={styles.section}>
+        <Title level={3} className={styles.sectionTitle}>
+          Create Household
+        </Title>
+        <Card className={styles.joinCard}>
+          <Space direction="vertical" style={{ width: "100%" }} size="middle">
+            <Input
+              placeholder="Enter household name"
+              value={createName}
+              onChange={(event) => setCreateName(event.target.value)}
+              onPressEnter={() => void handleCreateHousehold()}
+            />
+            <Button
+              type="primary"
+              icon={<PlusCircleOutlined />}
+              onClick={handleCreateHousehold}
+              loading={creating}
+            >
+              Create Household
+            </Button>
+          </Space>
+        </Card>
+      </section>
+
+      <Row gutter={[16, 16]} className={styles.stats}>
+        <Col xs={24} sm={12} lg={6}>
+          <Card className={styles.statCard}>
+            <div className={styles.statLabel}>Active households</div>
+            <div className={styles.statValue}>{households.length}</div>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card className={styles.statCard}>
+            <div className={styles.statLabel}>Owned households</div>
+            <div className={styles.statValue}>{ownedHouseholds.length}</div>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card className={styles.statCard}>
+            <div className={styles.statLabel}>Pantry routes ready</div>
+            <div className={styles.statValue}>{households.length}</div>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card className={styles.statCard}>
+            <div className={styles.statLabel}>Active invites</div>
+            <div className={styles.statValue}>{activeInvites}</div>
+          </Card>
+        </Col>
+      </Row>
+
+      <section className={styles.section}>
+        <Title level={3} className={styles.sectionTitle}>
+          My Households
+        </Title>
+        <Card className={styles.joinCard}>
+          {households.length === 0 ? (
+            <Paragraph type="secondary" style={{ margin: 0 }}>
+              No households yet. Create one below or join with an invite code.
+            </Paragraph>
+          ) : (
+            <Row gutter={[16, 16]}>
+              {households.map((household) => (
+                <Col xs={24} md={12} xl={8} key={household.householdId}>
+                  <Card className={styles.householdCard}>
+                    <div className={styles.householdTopRow}>
+                      <Tag
+                        className={styles.roleTag}
+                        color={household.role === "owner" ? "green" : "blue"}
+                      >
+                        {household.role.toUpperCase()}
+                      </Tag>
+                      <span className={styles.timeHint}>recently</span>
+                    </div>
+                    <Title level={4} style={{ marginBottom: 8 }}>
+                      {household.name}
+                    </Title>
+                    <p className={styles.householdMeta}>Invite code: {household.inviteCode}</p>
+                    <Space direction="vertical" style={{ width: "100%" }}>
+                      {household.role === "owner" && (
+                        <Button
+                          onClick={() => void handleRegenerateInviteCode(household.householdId)}
+                          loading={regeneratingId === household.householdId}
+                        >
+                          Regenerate Invite Code
+                        </Button>
+                      )}
+                      <Button className={styles.outlineButton} onClick={() => handleOpenPantry(household)}>
+                        View Pantry
+                      </Button>
+                    </Space>
+                  </Card>
+                </Col>
+              ))}
+            </Row>
+          )}
+        </Card>
+      </section>
+
+      <section className={styles.section}>
+        <Title level={3} className={styles.sectionTitle}>
+          Join a Household
+        </Title>
+        <Card className={styles.joinCard}>
+          <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+            <div className={styles.joinHeading}>Redeem Invite Code</div>
+            <p className={styles.joinDescription}>
+              Have an invite code from a friend or colleague? Enter it below to gain instant access to
+              their curated pantry and start collaborating.
+            </p>
+            <div className={styles.joinRow}>
+              <Input
+                placeholder="Enter invite code (e.g. AB-12345)"
+                value={joinCode}
+                onChange={(event) => setJoinCode(event.target.value)}
+                onPressEnter={() => void handleJoinHousehold()}
+              />
+              <Button type="primary" onClick={handleJoinHousehold} loading={joining}>
+                Join Household
+              </Button>
+            </div>
+            <div className={styles.joinInfoBox}>
+              Codes are unique, case-sensitive, and typically expire within 7 days. If you are having
+              trouble joining, contact the household owner for a new code.
+            </div>
+            {lastGeneratedCode && (
+              <div className={styles.inviteBox}>Latest generated invite code: {lastGeneratedCode}</div>
+            )}
+          </Space>
+        </Card>
+      </section>
+
+      <section className={styles.section}>
+        <Title level={3} className={styles.sectionTitle}>
+          Manage Pending Invitations
+        </Title>
+        <Card className={styles.joinCard}>
+          <Table
+            pagination={false}
+            rowKey="key"
+            locale={{ emptyText: "No pending invitations currently." }}
+            dataSource={invitationRows}
+            columns={[
+              { title: "Household", dataIndex: "household", key: "household" },
+              { title: "Invite Code", dataIndex: "inviteCode", key: "inviteCode" },
+              { title: "Created", dataIndex: "created", key: "created" },
+              { title: "Expires", dataIndex: "expires", key: "expires" },
+              {
+                title: "Actions",
+                key: "actions",
+                render: () => (
+                  <Button size="small" className={styles.outlineButton}>
+                    Revoke
+                  </Button>
+                ),
+              },
+            ]}
+          />
+        </Card>
+      </section>
+    </VirtualPantryAppShell>
   );
 }

--- a/app/stats/page.test.tsx
+++ b/app/stats/page.test.tsx
@@ -15,6 +15,12 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
 }));
 
+jest.mock("@/components/VirtualPantryAppShell", () => ({
+  VirtualPantryAppShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="shell">{children}</div>
+  ),
+}));
+
 jest.mock("@/hooks/useApi", () => ({
   useApi: () => ({ get: getMock, put: putMock }),
 }));
@@ -47,6 +53,9 @@ jest.mock("@/hooks/useLocalStorage", () => ({
 jest.mock("@ant-design/icons", () => ({
   EditOutlined: () => <span data-testid="edit-icon" />,
   WarningOutlined: () => <span data-testid="warn-icon" />,
+  RestOutlined: () => <span data-testid="rest-icon" />,
+  MinusCircleOutlined: () => <span data-testid="minus-icon" />,
+  ShoppingOutlined: () => <span data-testid="shop-icon" />,
 }));
 
 jest.mock("antd", () => {
@@ -66,19 +75,20 @@ jest.mock("antd", () => {
   const Space = ({ children }: any) => <div>{children}</div>;
   const Spin = () => <div>Loading...</div>;
   const Empty = ({ description }: any) => <div>{description}</div>;
+  Empty.PRESENTED_IMAGE_SIMPLE = "simple";
   const Tag = ({ children }: any) => <span>{children}</span>;
-  const Table = ({ dataSource }: any) => (
+  const Table = ({ dataSource, rowKey }: any) => (
     <table>
       <tbody>
-        {dataSource?.map((row: any) => (
-          <tr key={row.date}>
-            <td>{row.date}</td>
-            <td>{row.caloriesConsumed.toFixed(1)}</td>
+        {dataSource?.map((row: any, i: number) => (
+          <tr key={row[rowKey] ?? row.date ?? i}>
+            <td>{row.date ?? row.name ?? ""}</td>
           </tr>
         ))}
       </tbody>
     </table>
   );
+  const Select = () => <div data-testid="select" />;
   const DatePicker = ({ onChange, value }: any) => (
     <input
       aria-label="start-date"
@@ -111,6 +121,7 @@ jest.mock("antd", () => {
           validateFields: async () => ({ dailyCalorieTarget: 2000 }),
         },
       ],
+      useWatch: () => undefined,
       Item: FormItem,
     },
   );
@@ -132,6 +143,7 @@ jest.mock("antd", () => {
     Empty,
     Tag,
     Table,
+    Select,
     DatePicker,
     Typography,
     App,
@@ -174,6 +186,9 @@ describe("StatsPage", () => {
           dailyCalorieTarget: 2200,
         });
       }
+      if (url.includes("/consumption-logs")) {
+        return Promise.resolve([]);
+      }
       return Promise.reject(new Error(`unexpected ${url}`));
     });
   });
@@ -187,10 +202,11 @@ describe("StatsPage", () => {
         expect.stringMatching(/^\/households\/1\/stats\?startDate=\d{4}-\d{2}-\d{2}&endDate=\d{4}-\d{2}-\d{2}$/),
       );
       expect(getMock).toHaveBeenCalledWith("/households/1/budget");
+      expect(getMock).toHaveBeenCalledWith("/households/1/consumption-logs?limit=30");
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Calorie Management/i)).toBeInTheDocument();
+      expect(screen.getByText(/Pantry Overview/i)).toBeInTheDocument();
       expect(screen.getByText(/142,500 kcal/i)).toBeInTheDocument();
       expect(screen.getByText(/2,450 kcal \/ day/i)).toBeInTheDocument();
     });

--- a/app/stats/page.test.tsx
+++ b/app/stats/page.test.tsx
@@ -4,9 +4,11 @@ import StatsPage from "@/stats/page";
 
 const pushMock = jest.fn();
 const getMock = jest.fn();
+const putMock = jest.fn();
 const messageMock = {
   warning: jest.fn(),
   error: jest.fn(),
+  success: jest.fn(),
 };
 
 jest.mock("next/navigation", () => ({
@@ -14,7 +16,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("@/hooks/useApi", () => ({
-  useApi: () => ({ get: getMock }),
+  useApi: () => ({ get: getMock, put: putMock }),
 }));
 
 jest.mock("@/hooks/useLocalStorage", () => ({
@@ -23,19 +25,41 @@ jest.mock("@/hooks/useLocalStorage", () => ({
     if (key === "selectedHouseholdId") {
       return { value: 1, set: jest.fn(), clear: jest.fn() };
     }
+    if (key === "households") {
+      return {
+        value: [
+          {
+            householdId: 1,
+            name: "Test Home",
+            inviteCode: "abc",
+            ownerId: 99,
+            role: "owner",
+          },
+        ],
+        set: jest.fn(),
+        clear: jest.fn(),
+      };
+    }
     return { value: null, set: jest.fn(), clear: jest.fn() };
   },
 }));
 
+jest.mock("@ant-design/icons", () => ({
+  EditOutlined: () => <span data-testid="edit-icon" />,
+  WarningOutlined: () => <span data-testid="warn-icon" />,
+}));
+
 jest.mock("antd", () => {
-  const Button = ({ children, onClick, loading }: any) => (
-    <button onClick={onClick} data-loading={loading ? "true" : "false"}>
+  const Button = ({ children, onClick, loading, type, icon }: any) => (
+    <button type="button" onClick={onClick} data-loading={loading ? "true" : "false"} data-btn-type={type}>
+      {icon}
       {children}
     </button>
   );
-  const Card = ({ children, title }: any) => (
+  const Card = ({ children, title, extra }: any) => (
     <div>
-      {title ? <div>{title}</div> : null}
+      <div>{title}</div>
+      {extra ? <div data-testid="card-extra">{extra}</div> : null}
       <div>{children}</div>
     </div>
   );
@@ -46,7 +70,7 @@ jest.mock("antd", () => {
   const Table = ({ dataSource }: any) => (
     <table>
       <tbody>
-        {dataSource.map((row: any) => (
+        {dataSource?.map((row: any) => (
           <tr key={row.date}>
             <td>{row.date}</td>
             <td>{row.caloriesConsumed.toFixed(1)}</td>
@@ -55,12 +79,42 @@ jest.mock("antd", () => {
       </tbody>
     </table>
   );
-  const DatePicker = ({ onChange, placeholder }: any) => (
+  const DatePicker = ({ onChange, value }: any) => (
     <input
-      aria-label={placeholder}
-      onChange={() => onChange({ format: () => "2026-04-10" })}
+      aria-label="start-date"
+      data-testid="start-date"
+      onChange={() => onChange({ format: () => "2026-04-07" })}
     />
   );
+  const Row = ({ children }: any) => <div>{children}</div>;
+  const Col = ({ children }: any) => <div>{children}</div>;
+  const Progress = ({ format }: any) => <div>{format ? format(80) : "progress"}</div>;
+  const Modal = ({ children, open, title }: any) =>
+    open ? (
+      <div data-testid="budget-modal">
+        <div>{title}</div>
+        {children}
+      </div>
+    ) : null;
+  const FormItem = ({ children, label }: any) => (
+    <div>
+      {label ? <label>{label}</label> : null}
+      {children}
+    </div>
+  );
+  const Form = Object.assign(
+    ({ children }: any) => <form>{children}</form>,
+    {
+      useForm: () => [
+        {
+          setFieldsValue: jest.fn(),
+          validateFields: async () => ({ dailyCalorieTarget: 2000 }),
+        },
+      ],
+      Item: FormItem,
+    },
+  );
+  const InputNumber = () => <input aria-label="daily-calorie-target" />;
   const Typography = {
     Title: ({ children }: any) => <h1>{children}</h1>,
     Paragraph: ({ children }: any) => <p>{children}</p>,
@@ -70,60 +124,89 @@ jest.mock("antd", () => {
     useApp: () => ({ message: messageMock }),
   };
 
-  return { Button, Card, Space, Spin, Empty, Tag, Table, DatePicker, Typography, App };
+  return {
+    Button,
+    Card,
+    Space,
+    Spin,
+    Empty,
+    Tag,
+    Table,
+    DatePicker,
+    Typography,
+    App,
+    Row,
+    Col,
+    Progress,
+    Modal,
+    Form,
+    InputNumber,
+  };
 });
 
 describe("StatsPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getMock.mockImplementation((url: string) => {
+      const today = new Date().toISOString().slice(0, 10);
+      if (url.includes("/pantry")) {
+        return Promise.resolve({ items: [{ id: 1 }, { id: 2 }], totalCalories: 142500 });
+      }
+      if (url.includes("/stats")) {
+        return Promise.resolve({
+          startDate: "2026-04-07",
+          endDate: today,
+          dailyCalorieTarget: 2200,
+          averageDailyCalories: 2450,
+          totalCaloriesConsumed: 10000,
+          dailyBreakdown: [{ date: today, caloriesConsumed: 2580 }],
+          comparisonToBudget: {
+            status: "OVER_BUDGET",
+            differenceFromTarget: 250,
+            percentageOfTarget: 111,
+          },
+        });
+      }
+      if (url.includes("/budget")) {
+        return Promise.resolve({
+          budgetId: 10,
+          householdId: 1,
+          dailyCalorieTarget: 2200,
+        });
+      }
+      return Promise.reject(new Error(`unexpected ${url}`));
+    });
   });
 
-  it("loads and renders household stats", async () => {
-    getMock.mockResolvedValueOnce({
-      startDate: "2026-04-10",
-      endDate: "2026-04-10",
-      dailyCalorieTarget: 2000,
-      averageDailyCalories: 1800,
-      totalCaloriesConsumed: 1800,
-      dailyBreakdown: [{ date: "2026-04-10", caloriesConsumed: 1800 }],
-      comparisonToBudget: {
-        status: "UNDER_BUDGET",
-        differenceFromTarget: -200,
-        percentageOfTarget: 90,
-      },
-    });
-
+  it("loads pantry, stats, and budget and shows dashboard cards", async () => {
     render(<StatsPage />);
 
     await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith("/households/1/pantry");
       expect(getMock).toHaveBeenCalledWith(
-        "/households/1/stats?startDate=2026-04-07&endDate=2026-04-13",
+        expect.stringMatching(/^\/households\/1\/stats\?startDate=\d{4}-\d{2}-\d{2}&endDate=\d{4}-\d{2}-\d{2}$/),
       );
+      expect(getMock).toHaveBeenCalledWith("/households/1/budget");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Calorie Management/i)).toBeInTheDocument();
+      expect(screen.getByText(/142,500 kcal/i)).toBeInTheDocument();
+      expect(screen.getByText(/2,450 kcal \/ day/i)).toBeInTheDocument();
     });
   });
 
-  it("renders stats after clicking load button", async () => {
-    getMock.mockResolvedValue({
-      startDate: "2026-04-10",
-      endDate: "2026-04-10",
-      dailyCalorieTarget: 2000,
-      averageDailyCalories: 1800,
-      totalCaloriesConsumed: 1800,
-      dailyBreakdown: [{ date: "2026-04-10", caloriesConsumed: 1800 }],
-      comparisonToBudget: {
-        status: "UNDER_BUDGET",
-        differenceFromTarget: -200,
-        percentageOfTarget: 90,
-      },
-    });
-
+  it("opens budget modal when owner clicks Edit", async () => {
     render(<StatsPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Load stats" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Edit/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("UNDER_BUDGET")).toBeInTheDocument();
-      expect(screen.getByText("2026-04-10")).toBeInTheDocument();
+      expect(screen.getByTestId("budget-modal")).toBeInTheDocument();
     });
   });
 });

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,16 +1,54 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { DatePicker, Button, Card, Empty, Space, Spin, Table, Tag, Typography, App } from "antd";
+import {
+  App,
+  Button,
+  Card,
+  Col,
+  DatePicker,
+  Empty,
+  Form,
+  InputNumber,
+  Modal,
+  Progress,
+  Row,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import { EditOutlined, WarningOutlined } from "@ant-design/icons";
 import dayjs, { Dayjs } from "dayjs";
 import { useApi } from "@/hooks/useApi";
 import useLocalStorage from "@/hooks/useLocalStorage";
+import type { ApplicationError } from "@/types/error";
+import type { HouseholdBudget } from "@/types/budget";
+import type { HouseholdWithRole } from "@/types/household";
+import type { PantryOverview } from "@/types/pantry";
 import type { HouseholdStats } from "@/types/stats";
 
 const { Title, Paragraph, Text } = Typography;
 
-function comparisonColor(status: string): string {
+const ACCENT = "#16a34a";
+const DANGER = "#dc2626";
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as ApplicationError).status === 404
+  );
+}
+
+function formatKcal(value: number): string {
+  return `${Math.round(value).toLocaleString()} kcal`;
+}
+
+function comparisonTagColor(status: string): string {
   switch (status) {
     case "OVER_BUDGET":
       return "red";
@@ -29,145 +67,341 @@ export default function StatsPage() {
   const { message } = App.useApp();
 
   const { value: selectedHouseholdId } = useLocalStorage<number | null>("selectedHouseholdId", null);
+  const { value: cachedHouseholds } = useLocalStorage<HouseholdWithRole[]>("households", []);
 
-  const [startDate, setStartDate] = useState<Dayjs | null>(dayjs().subtract(6, "day"));
-  const [endDate, setEndDate] = useState<Dayjs | null>(dayjs());
+  const householdRole = useMemo(() => {
+    if (!selectedHouseholdId) return null;
+    return cachedHouseholds.find((h) => h.householdId === selectedHouseholdId)?.role ?? null;
+  }, [cachedHouseholds, selectedHouseholdId]);
+  const isOwner = householdRole === "owner";
+
+  const [startDate, setStartDate] = useState<Dayjs | null>(() => dayjs().subtract(7, "day"));
   const [loading, setLoading] = useState(false);
+  const [pantry, setPantry] = useState<PantryOverview | null>(null);
   const [stats, setStats] = useState<HouseholdStats | null>(null);
-  const [hasLoaded, setHasLoaded] = useState(false);
+  const [budgetRecord, setBudgetRecord] = useState<HouseholdBudget | null>(null);
+  const [budgetModalOpen, setBudgetModalOpen] = useState(false);
+  const [savingBudget, setSavingBudget] = useState(false);
+  const [budgetForm] = Form.useForm<{ dailyCalorieTarget: number }>();
 
-  const canLoad = useMemo(() => {
-    return Boolean(selectedHouseholdId && startDate && endDate);
-  }, [selectedHouseholdId, startDate, endDate]);
-
-  const loadStats = async () => {
-    if (!selectedHouseholdId) {
-      message.warning("Please select a household first.");
+  const loadDashboard = useCallback(async () => {
+    if (!selectedHouseholdId || !startDate) {
       return;
     }
-    if (!startDate || !endDate) {
-      message.warning("Please select both start and end dates.");
-      return;
-    }
+
+    const endStr = dayjs().format("YYYY-MM-DD");
+    const startStr = startDate.format("YYYY-MM-DD");
 
     setLoading(true);
     try {
-      const result = await api.get<HouseholdStats>(
-        `/households/${selectedHouseholdId}/stats?startDate=${startDate.format("YYYY-MM-DD")}&endDate=${endDate.format("YYYY-MM-DD")}`,
-      );
-      setStats(result);
-      setHasLoaded(true);
+      const [pantryRes, statsRes] = await Promise.all([
+        api.get<PantryOverview>(`/households/${selectedHouseholdId}/pantry`),
+        api.get<HouseholdStats>(
+          `/households/${selectedHouseholdId}/stats?startDate=${startStr}&endDate=${endStr}`,
+        ),
+      ]);
+      setPantry(pantryRes);
+      setStats(statsRes);
+
+      try {
+        const b = await api.get<HouseholdBudget>(`/households/${selectedHouseholdId}/budget`);
+        setBudgetRecord(b);
+      } catch (error) {
+        if (isNotFound(error)) {
+          setBudgetRecord(null);
+        } else {
+          throw error;
+        }
+      }
     } catch (error) {
+      setPantry(null);
       setStats(null);
-      setHasLoaded(true);
-      message.error(error instanceof Error ? error.message : "Failed to load stats.");
+      setBudgetRecord(null);
+      message.error(error instanceof Error ? error.message : "Failed to load dashboard.");
     } finally {
       setLoading(false);
     }
-  };
+  }, [api, message, selectedHouseholdId, startDate]);
 
   useEffect(() => {
-    if (canLoad) {
-      void loadStats();
+    if (selectedHouseholdId && startDate) {
+      void loadDashboard();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [loadDashboard, selectedHouseholdId, startDate]);
+
+  const todayStr = dayjs().format("YYYY-MM-DD");
+  const dailyGoal = stats?.dailyCalorieTarget ?? budgetRecord?.dailyCalorieTarget ?? null;
+  const actualToday = useMemo(() => {
+    if (!stats?.dailyBreakdown?.length) return 0;
+    const row = stats.dailyBreakdown.find((d) => d.date === todayStr);
+    return row?.caloriesConsumed ?? 0;
+  }, [stats, todayStr]);
+
+  const todayVsGoalPercent = useMemo(() => {
+    if (dailyGoal === null || dailyGoal <= 0) return 0;
+    return (actualToday / dailyGoal) * 100;
+  }, [actualToday, dailyGoal]);
+
+  const todayOverLabel = useMemo(() => {
+    if (dailyGoal === null || dailyGoal <= 0) return null;
+    if (actualToday <= dailyGoal) return null;
+    const pct = ((actualToday / dailyGoal) * 100 - 100).toFixed(0);
+    return `+${pct}% OVER BUDGET (today)`;
+  }, [actualToday, dailyGoal]);
+
+  const openBudgetModal = () => {
+    const initial = dailyGoal ?? 2200;
+    budgetForm.setFieldsValue({ dailyCalorieTarget: initial });
+    setBudgetModalOpen(true);
+  };
+
+  const submitBudget = async () => {
+    if (!selectedHouseholdId) return;
+    const values = await budgetForm.validateFields();
+    setSavingBudget(true);
+    try {
+      const updated = await api.put<HouseholdBudget>(`/households/${selectedHouseholdId}/budget`, {
+        dailyCalorieTarget: values.dailyCalorieTarget,
+      });
+      setBudgetRecord(updated);
+      message.success("Budget saved.");
+      setBudgetModalOpen(false);
+      await loadDashboard();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : "Could not save budget.");
+    } finally {
+      setSavingBudget(false);
+    }
+  };
 
   return (
-    <div style={{ padding: 24, maxWidth: 1100, margin: "0 auto" }}>
+    <div style={{ padding: 24, maxWidth: 1200, margin: "0 auto" }}>
       <Space direction="vertical" size="large" style={{ width: "100%" }}>
-        <Space style={{ width: "100%", justifyContent: "space-between", flexWrap: "wrap" }}>
-          <div>
-            <Title level={2} style={{ marginBottom: 0 }}>Household Statistics</Title>
+        <Row justify="space-between" align="middle" gutter={[16, 16]}>
+          <Col flex="auto">
+            <Title level={2} style={{ marginBottom: 4 }}>
+              Calorie Management
+            </Title>
             <Paragraph type="secondary" style={{ marginBottom: 0 }}>
-              View average consumption, total calories, and budget comparison for the selected household.
+              Monitor pantry energy, average consumption since a start date, and budget vs actuals for
+              your household.
             </Paragraph>
-          </div>
-          <Button onClick={() => router.push("/households")}>Back to households</Button>
-        </Space>
-
-        <Card>
-          <Space wrap>
-            <DatePicker
-              value={startDate}
-              onChange={(value) => setStartDate(value)}
-              placeholder="Start date"
-            />
-            <DatePicker
-              value={endDate}
-              onChange={(value) => setEndDate(value)}
-              placeholder="End date"
-            />
-            <Button type="primary" onClick={() => void loadStats()} loading={loading}>
-              Load stats
-            </Button>
-          </Space>
-        </Card>
+          </Col>
+          <Col>
+            <Button onClick={() => router.push("/households")}>Back to households</Button>
+          </Col>
+        </Row>
 
         {!selectedHouseholdId ? (
-          <Empty description="No household selected yet. Go to Households and choose one first." />
-        ) : loading ? (
-          <Card><Spin /></Card>
-        ) : stats ? (
-          <Space direction="vertical" size="large" style={{ width: "100%" }}>
-            <Space wrap style={{ width: "100%" }}>
-              <Card style={{ minWidth: 220 }}>
-                <Text type="secondary">Average daily calories</Text>
-                <Title level={3} style={{ margin: 0 }}>{stats.averageDailyCalories.toFixed(1)}</Title>
-              </Card>
-              <Card style={{ minWidth: 220 }}>
-                <Text type="secondary">Total calories consumed</Text>
-                <Title level={3} style={{ margin: 0 }}>{stats.totalCaloriesConsumed.toFixed(1)}</Title>
-              </Card>
-              <Card style={{ minWidth: 220 }}>
-                <Text type="secondary">Daily target</Text>
-                <Title level={3} style={{ margin: 0 }}>
-                  {stats.dailyCalorieTarget !== null ? stats.dailyCalorieTarget.toFixed(1) : "—"}
-                </Title>
-              </Card>
-            </Space>
-
-            <Card title="Budget comparison">
-              {stats.comparisonToBudget ? (
-                <Space direction="vertical">
-                  <Tag color={comparisonColor(stats.comparisonToBudget.status)}>
-                    {stats.comparisonToBudget.status}
-                  </Tag>
-                  <Text>
-                    Difference from target: {stats.comparisonToBudget.differenceFromTarget.toFixed(1)}
-                  </Text>
-                  <Text>
-                    Percentage of target: {stats.comparisonToBudget.percentageOfTarget.toFixed(1)}%
-                  </Text>
-                </Space>
-              ) : (
-                <Empty description="No household budget has been set yet." />
-              )}
-            </Card>
-
-            <Card title="Daily breakdown">
-              <Table
-                rowKey="date"
-                pagination={false}
-                dataSource={stats.dailyBreakdown}
-                columns={[
-                  { title: "Date", dataIndex: "date", key: "date" },
-                  {
-                    title: "Calories consumed",
-                    dataIndex: "caloriesConsumed",
-                    key: "caloriesConsumed",
-                    render: (value: number) => value.toFixed(1),
-                  },
-                ]}
-              />
-            </Card>
-          </Space>
-        ) : hasLoaded ? (
-          <Empty description="No stats available for the selected range." />
+          <Empty description="No household selected. Open Households and pick one first." />
+        ) : loading && !stats ? (
+          <Card>
+            <Spin size="large" />
+          </Card>
         ) : (
-          <Empty description="Choose a date range and load household statistics." />
+          <>
+            <Row gutter={[16, 16]}>
+              <Col xs={24} md={8}>
+                <Card
+                  title={
+                    <span style={{ color: ACCENT, fontWeight: 600 }}>Energy Reservoir</span>
+                  }
+                  variant="borderless"
+                  style={{
+                    borderRadius: 12,
+                    border: `1px solid ${ACCENT}33`,
+                    minHeight: 200,
+                  }}
+                >
+                  <Space direction="vertical" size="small" style={{ width: "100%" }}>
+                    <Text type="secondary">Total calories stored in pantry</Text>
+                    <Title level={3} style={{ margin: 0 }}>
+                      {pantry ? formatKcal(pantry.totalCalories) : "—"}
+                    </Title>
+                    <Text type="secondary">
+                      {pantry ? `${pantry.items.length} item(s)` : ""}
+                    </Text>
+                  </Space>
+                </Card>
+              </Col>
+
+              <Col xs={24} md={8}>
+                <Card
+                  title={
+                    <span style={{ color: ACCENT, fontWeight: 600 }}>Daily Average</span>
+                  }
+                  extra={
+                    <DatePicker
+                      value={startDate}
+                      onChange={(v) => setStartDate(v)}
+                      allowClear={false}
+                      size="small"
+                    />
+                  }
+                  variant="borderless"
+                  style={{
+                    borderRadius: 12,
+                    border: `1px solid ${ACCENT}33`,
+                    minHeight: 200,
+                  }}
+                >
+                  <Space direction="vertical" size="small" style={{ width: "100%" }}>
+                    <Text type="secondary">Average consumed per day</Text>
+                    <Title level={3} style={{ margin: 0 }}>
+                      {stats ? `${Math.round(stats.averageDailyCalories).toLocaleString()} kcal / day` : "—"}
+                    </Title>
+                    {stats && startDate ? (
+                      <Text type="secondary" style={{ fontSize: 12 }}>
+                        Calculated from {startDate.format("MMM D, YYYY")} to present (
+                        {dayjs(stats.endDate).format("MMM D, YYYY")})
+                      </Text>
+                    ) : null}
+                  </Space>
+                </Card>
+              </Col>
+
+              <Col xs={24} md={8}>
+                <Card
+                  title={
+                    <span style={{ color: ACCENT, fontWeight: 600 }}>Budget Control</span>
+                  }
+                  extra={
+                    isOwner ? (
+                      <Button
+                        type="text"
+                        size="small"
+                        icon={<EditOutlined />}
+                        onClick={openBudgetModal}
+                        aria-label="Edit daily calorie budget"
+                      >
+                        Edit
+                      </Button>
+                    ) : null
+                  }
+                  variant="borderless"
+                  style={{
+                    borderRadius: 12,
+                    border: `1px solid ${ACCENT}33`,
+                    minHeight: 200,
+                  }}
+                >
+                  <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+                    <div>
+                      <Text type="secondary">Daily goal</Text>
+                      <div>
+                        <Text strong>
+                          {dailyGoal !== null ? formatKcal(dailyGoal) : "Not set"}
+                        </Text>
+                      </div>
+                    </div>
+                    <div>
+                      <Text type="secondary">Actual today</Text>
+                      <div>
+                        <Text strong style={{ color: todayVsGoalPercent > 100 ? DANGER : undefined }}>
+                          {stats ? formatKcal(actualToday) : "—"}
+                        </Text>
+                      </div>
+                    </div>
+
+                    {dailyGoal !== null && dailyGoal > 0 ? (
+                      <>
+                        <Progress
+                          percent={Math.min(Math.round(todayVsGoalPercent), 100)}
+                          status={todayVsGoalPercent > 100 ? "exception" : "active"}
+                          strokeColor={todayVsGoalPercent > 100 ? DANGER : ACCENT}
+                          showInfo
+                          format={(p) => `${p ?? 0}% of daily goal (today)`}
+                        />
+                        {todayOverLabel ? (
+                          <Tag color="error" icon={<WarningOutlined />}>
+                            {todayOverLabel}
+                          </Tag>
+                        ) : null}
+                      </>
+                    ) : (
+                      <Text type="secondary">Set a daily calorie budget to enable comparisons.</Text>
+                    )}
+
+                    {stats?.comparisonToBudget ? (
+                      <div>
+                        <Text type="secondary" style={{ fontSize: 12 }}>
+                          Period average vs budget:
+                        </Text>
+                        <div>
+                          <Tag color={comparisonTagColor(stats.comparisonToBudget.status)}>
+                            {stats.comparisonToBudget.status.replace(/_/g, " ")}
+                          </Tag>
+                          <Text style={{ marginLeft: 8 }}>
+                            Avg {stats.averageDailyCalories.toFixed(0)} vs target{" "}
+                            {stats.dailyCalorieTarget?.toFixed(0) ?? "—"} kcal/day
+                          </Text>
+                        </div>
+                      </div>
+                    ) : null}
+                  </Space>
+                </Card>
+              </Col>
+            </Row>
+
+            {stats ? (
+              <Card title="Daily breakdown" style={{ borderRadius: 12 }}>
+                <Table
+                  rowKey="date"
+                  pagination={false}
+                  size="small"
+                  dataSource={stats.dailyBreakdown}
+                  columns={[
+                    { title: "Date", dataIndex: "date", key: "date" },
+                    {
+                      title: "Calories consumed",
+                      dataIndex: "caloriesConsumed",
+                      key: "caloriesConsumed",
+                      render: (value: number) => value.toFixed(1),
+                    },
+                  ]}
+                />
+              </Card>
+            ) : null}
+          </>
         )}
       </Space>
+
+      <Modal
+        title="Daily calorie budget"
+        open={budgetModalOpen}
+        onCancel={() => setBudgetModalOpen(false)}
+        onOk={() => void submitBudget()}
+        confirmLoading={savingBudget}
+        okText="Save"
+        destroyOnClose
+      >
+        <Paragraph type="secondary">
+          Set the ideal total calories your household aims to consume per day. Only the household
+          owner can change this.
+        </Paragraph>
+        <Form form={budgetForm} layout="vertical">
+          <Form.Item
+            label="Daily calorie target"
+            name="dailyCalorieTarget"
+            rules={[
+              { required: true, message: "Enter a calorie target" },
+              {
+                type: "number",
+                min: 1,
+                max: 50000,
+                message: "Enter a value between 1 and 50000",
+              },
+            ]}
+          >
+            <InputNumber
+              min={1}
+              max={50000}
+              style={{ width: "100%" }}
+              addonAfter="kcal / day"
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 }

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
 import {
   App,
   Button,
@@ -14,26 +13,56 @@ import {
   Modal,
   Progress,
   Row,
+  Select,
   Space,
   Spin,
   Table,
   Tag,
   Typography,
 } from "antd";
-import { EditOutlined, WarningOutlined } from "@ant-design/icons";
+import type { TableProps } from "antd";
+import {
+  EditOutlined,
+  MinusCircleOutlined,
+  RestOutlined,
+  ShoppingOutlined,
+  WarningOutlined,
+} from "@ant-design/icons";
 import dayjs, { Dayjs } from "dayjs";
 import { useApi } from "@/hooks/useApi";
 import useLocalStorage from "@/hooks/useLocalStorage";
+import { VirtualPantryAppShell } from "@/components/VirtualPantryAppShell";
 import type { ApplicationError } from "@/types/error";
 import type { HouseholdBudget } from "@/types/budget";
 import type { HouseholdWithRole } from "@/types/household";
-import type { PantryOverview } from "@/types/pantry";
+import type { ConsumptionLogEntry } from "@/types/consumption";
+import type { ConsumePantryItemResponse, PantryItem, PantryOverview } from "@/types/pantry";
 import type { HouseholdStats } from "@/types/stats";
+import statsStyles from "@/styles/stats.module.css";
 
 const { Title, Paragraph, Text } = Typography;
 
-const ACCENT = "#16a34a";
-const DANGER = "#dc2626";
+const FOREST = "#1b5e20";
+const DANGER = "#c62828";
+const MUTED = "#5d6a5d";
+
+type ActivityEntry = {
+  id: string;
+  at: string;
+  productName: string;
+  deltaKcal: number;
+  consumedQuantity: number;
+};
+
+function logsToActivity(logs: ConsumptionLogEntry[]): ActivityEntry[] {
+  return logs.map((log) => ({
+    id: `log-${log.logId}`,
+    at: log.consumedAt,
+    productName: log.productName,
+    deltaKcal: -log.consumedCalories,
+    consumedQuantity: log.consumedQuantity,
+  }));
+}
 
 function isNotFound(error: unknown): boolean {
   return (
@@ -61,8 +90,18 @@ function comparisonTagColor(status: string): string {
   }
 }
 
+function inferCategory(name: string): { label: string; color: string } {
+  const n = name.trim();
+  if (/milk|cheese|yogurt|cream|butter|dairy/i.test(n)) {
+    return { label: "DAIRY", color: "gold" };
+  }
+  if (/fruit|berry|vegetable|lettuce|tomato|produce|apple|orange/i.test(n)) {
+    return { label: "PRODUCE", color: "green" };
+  }
+  return { label: "PANTRY", color: "cyan" };
+}
+
 export default function StatsPage() {
-  const router = useRouter();
   const api = useApi();
   const { message } = App.useApp();
 
@@ -84,6 +123,16 @@ export default function StatsPage() {
   const [savingBudget, setSavingBudget] = useState(false);
   const [budgetForm] = Form.useForm<{ dailyCalorieTarget: number }>();
 
+  const [consumeModalOpen, setConsumeModalOpen] = useState(false);
+  const [consuming, setConsuming] = useState(false);
+  const [consumeForm] = Form.useForm<{ itemId: number; quantity: number }>();
+  const selectedConsumeItemId = Form.useWatch("itemId", consumeForm);
+  const selectedConsumeItem = useMemo(
+    () => pantry?.items.find((i) => i.id === selectedConsumeItemId),
+    [pantry?.items, selectedConsumeItemId],
+  );
+  const [activity, setActivity] = useState<ActivityEntry[]>([]);
+
   const loadDashboard = useCallback(async () => {
     if (!selectedHouseholdId || !startDate) {
       return;
@@ -94,14 +143,18 @@ export default function StatsPage() {
 
     setLoading(true);
     try {
-      const [pantryRes, statsRes] = await Promise.all([
+      const [pantryRes, statsRes, logsRes] = await Promise.all([
         api.get<PantryOverview>(`/households/${selectedHouseholdId}/pantry`),
         api.get<HouseholdStats>(
           `/households/${selectedHouseholdId}/stats?startDate=${startStr}&endDate=${endStr}`,
         ),
+        api.get<ConsumptionLogEntry[]>(
+          `/households/${selectedHouseholdId}/consumption-logs?limit=30`,
+        ),
       ]);
       setPantry(pantryRes);
       setStats(statsRes);
+      setActivity(logsToActivity(logsRes));
 
       try {
         const b = await api.get<HouseholdBudget>(`/households/${selectedHouseholdId}/budget`);
@@ -117,6 +170,7 @@ export default function StatsPage() {
       setPantry(null);
       setStats(null);
       setBudgetRecord(null);
+      setActivity([]);
       message.error(error instanceof Error ? error.message : "Failed to load dashboard.");
     } finally {
       setLoading(false);
@@ -149,6 +203,11 @@ export default function StatsPage() {
     return `+${pct}% OVER BUDGET (today)`;
   }, [actualToday, dailyGoal]);
 
+  const estimatedCoverageDays = useMemo(() => {
+    if (!pantry || !stats || stats.averageDailyCalories <= 0) return null;
+    return Math.max(0, Math.floor(pantry.totalCalories / stats.averageDailyCalories));
+  }, [pantry, stats]);
+
   const openBudgetModal = () => {
     const initial = dailyGoal ?? 2200;
     budgetForm.setFieldsValue({ dailyCalorieTarget: initial });
@@ -174,52 +233,146 @@ export default function StatsPage() {
     }
   };
 
-  return (
-    <div style={{ padding: 24, maxWidth: 1200, margin: "0 auto" }}>
-      <Space direction="vertical" size="large" style={{ width: "100%" }}>
-        <Row justify="space-between" align="middle" gutter={[16, 16]}>
-          <Col flex="auto">
-            <Title level={2} style={{ marginBottom: 4 }}>
-              Calorie Management
-            </Title>
-            <Paragraph type="secondary" style={{ marginBottom: 0 }}>
-              Monitor pantry energy, average consumption since a start date, and budget vs actuals for
-              your household.
-            </Paragraph>
-          </Col>
-          <Col>
-            <Button onClick={() => router.push("/households")}>Back to households</Button>
-          </Col>
-        </Row>
+  const openConsumeModal = () => {
+    if (!pantry?.items.length) {
+      message.info("Add items to your pantry before recording consumption.");
+      return;
+    }
+    const first = pantry.items[0];
+    consumeForm.setFieldsValue({ itemId: first.id, quantity: 1 });
+    setConsumeModalOpen(true);
+  };
 
+  const submitConsumption = async () => {
+    if (!selectedHouseholdId) return;
+    const values = await consumeForm.validateFields();
+    const item = pantry?.items.find((i) => i.id === values.itemId);
+    if (!item) {
+      message.error("Selected item is no longer in the pantry.");
+      return;
+    }
+    if (values.quantity > item.count) {
+      message.error("Quantity cannot exceed available units.");
+      return;
+    }
+    setConsuming(true);
+    try {
+      const res = await api.post<ConsumePantryItemResponse>(
+        `/households/${selectedHouseholdId}/pantry/${values.itemId}/consume`,
+        { quantity: values.quantity },
+      );
+      message.success(
+        res.removed
+          ? "Item fully consumed and removed from pantry."
+          : "Consumption recorded.",
+      );
+      setConsumeModalOpen(false);
+
+      await loadDashboard();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : "Could not record consumption.");
+    } finally {
+      setConsuming(false);
+    }
+  };
+
+  const inventoryColumns: TableProps<PantryItem>["columns"] = useMemo(
+    () => [
+      {
+        title: "Product",
+        dataIndex: "name",
+        key: "name",
+        render: (name: string) => (
+          <Text strong style={{ color: "#1b2a1b" }}>
+            {name}
+          </Text>
+        ),
+      },
+      {
+        title: "Category",
+        key: "category",
+        width: 120,
+        render: (_: unknown, record: PantryItem) => {
+          const { label, color } = inferCategory(record.name);
+          return (
+            <Tag className={statsStyles.categoryTag} color={color}>
+              {label}
+            </Tag>
+          );
+        },
+      },
+      {
+        title: "Quantity",
+        key: "count",
+        width: 110,
+        render: (_: unknown, record: PantryItem) => (
+          <span>
+            {record.count} × unit
+          </span>
+        ),
+      },
+      {
+        title: "Calories",
+        key: "cals",
+        width: 120,
+        render: (_: unknown, record: PantryItem) => (
+          <Text strong>{Math.round(record.kcalPerPackage * record.count).toLocaleString()} kcal</Text>
+        ),
+      },
+      {
+        title: "Status",
+        key: "status",
+        width: 120,
+        render: (_: unknown, record: PantryItem) =>
+          record.count <= 2 ? (
+            <Tag color="orange">Low stock</Tag>
+          ) : (
+            <Tag color="success">In stock</Tag>
+          ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <VirtualPantryAppShell activeNav="pantry">
+      <div className={statsStyles.pageHeader}>
+        <Title level={2} className={statsStyles.pageTitle}>
+          Pantry Overview
+        </Title>
+        <Paragraph className={statsStyles.pageSubtitle}>
+          Energy reservoir, consumption flow, and budget control — with current inventory and a record of
+          what you use from the pantry.
+        </Paragraph>
+      </div>
+
+      <Space direction="vertical" size="large" style={{ width: "100%" }}>
         {!selectedHouseholdId ? (
-          <Empty description="No household selected. Open Households and pick one first." />
+          <div className={statsStyles.emptyWrap}>
+            <Empty description="No household selected. Open Households and pick one first." />
+          </div>
         ) : loading && !stats ? (
-          <Card>
+          <Card className={statsStyles.spinCard}>
             <Spin size="large" />
           </Card>
         ) : (
           <>
-            <Row gutter={[16, 16]}>
+            <Row gutter={[20, 20]} className={statsStyles.metricGrid}>
               <Col xs={24} md={8}>
                 <Card
-                  title={
-                    <span style={{ color: ACCENT, fontWeight: 600 }}>Energy Reservoir</span>
-                  }
+                  className={statsStyles.metricCard}
+                  title={<span className={statsStyles.cardTitle}>Energy reservoir</span>}
                   variant="borderless"
-                  style={{
-                    borderRadius: 12,
-                    border: `1px solid ${ACCENT}33`,
-                    minHeight: 200,
-                  }}
                 >
                   <Space direction="vertical" size="small" style={{ width: "100%" }}>
-                    <Text type="secondary">Total calories stored in pantry</Text>
-                    <Title level={3} style={{ margin: 0 }}>
+                    <div className={statsStyles.metricLead}>Total nutritional value in your pantry</div>
+                    <Title level={3} className={statsStyles.metricValue}>
                       {pantry ? formatKcal(pantry.totalCalories) : "—"}
                     </Title>
-                    <Text type="secondary">
-                      {pantry ? `${pantry.items.length} item(s)` : ""}
+                    <Text className={statsStyles.metricFootnote}>
+                      {pantry
+                        ? `${pantry.items.length} item(s) currently in your digital atelier.`
+                        : ""}
                     </Text>
                   </Space>
                 </Card>
@@ -227,9 +380,8 @@ export default function StatsPage() {
 
               <Col xs={24} md={8}>
                 <Card
-                  title={
-                    <span style={{ color: ACCENT, fontWeight: 600 }}>Daily Average</span>
-                  }
+                  className={statsStyles.metricCard}
+                  title={<span className={statsStyles.cardTitle}>Consumption flow</span>}
                   extra={
                     <DatePicker
                       value={startDate}
@@ -239,21 +391,17 @@ export default function StatsPage() {
                     />
                   }
                   variant="borderless"
-                  style={{
-                    borderRadius: 12,
-                    border: `1px solid ${ACCENT}33`,
-                    minHeight: 200,
-                  }}
                 >
                   <Space direction="vertical" size="small" style={{ width: "100%" }}>
-                    <Text type="secondary">Average consumed per day</Text>
-                    <Title level={3} style={{ margin: 0 }}>
-                      {stats ? `${Math.round(stats.averageDailyCalories).toLocaleString()} kcal / day` : "—"}
+                    <div className={statsStyles.metricLead}>Daily average since start date</div>
+                    <Title level={3} className={statsStyles.metricValue}>
+                      {stats
+                        ? `${Math.round(stats.averageDailyCalories).toLocaleString()} kcal / day`
+                        : "—"}
                     </Title>
                     {stats && startDate ? (
-                      <Text type="secondary" style={{ fontSize: 12 }}>
-                        Calculated from {startDate.format("MMM D, YYYY")} to present (
-                        {dayjs(stats.endDate).format("MMM D, YYYY")})
+                      <Text className={statsStyles.metricFootnote}>
+                        From {startDate.format("MMM D, YYYY")} to {dayjs(stats.endDate).format("MMM D, YYYY")}
                       </Text>
                     ) : null}
                   </Space>
@@ -262,9 +410,8 @@ export default function StatsPage() {
 
               <Col xs={24} md={8}>
                 <Card
-                  title={
-                    <span style={{ color: ACCENT, fontWeight: 600 }}>Budget Control</span>
-                  }
+                  className={statsStyles.metricCard}
+                  title={<span className={statsStyles.cardTitle}>Budget control</span>}
                   extra={
                     isOwner ? (
                       <Button
@@ -273,31 +420,33 @@ export default function StatsPage() {
                         icon={<EditOutlined />}
                         onClick={openBudgetModal}
                         aria-label="Edit daily calorie budget"
+                        style={{ color: FOREST, fontWeight: 600 }}
                       >
                         Edit
                       </Button>
                     ) : null
                   }
                   variant="borderless"
-                  style={{
-                    borderRadius: 12,
-                    border: `1px solid ${ACCENT}33`,
-                    minHeight: 200,
-                  }}
                 >
                   <Space direction="vertical" size="middle" style={{ width: "100%" }}>
                     <div>
-                      <Text type="secondary">Daily goal</Text>
+                      <Text style={{ color: MUTED }}>Daily goal</Text>
                       <div>
-                        <Text strong>
+                        <Text strong style={{ fontSize: 16, color: "#1b2a1b" }}>
                           {dailyGoal !== null ? formatKcal(dailyGoal) : "Not set"}
                         </Text>
                       </div>
                     </div>
                     <div>
-                      <Text type="secondary">Actual today</Text>
+                      <Text style={{ color: MUTED }}>Actual today</Text>
                       <div>
-                        <Text strong style={{ color: todayVsGoalPercent > 100 ? DANGER : undefined }}>
+                        <Text
+                          strong
+                          style={{
+                            fontSize: 16,
+                            color: todayVsGoalPercent > 100 ? DANGER : FOREST,
+                          }}
+                        >
                           {stats ? formatKcal(actualToday) : "—"}
                         </Text>
                       </div>
@@ -308,7 +457,8 @@ export default function StatsPage() {
                         <Progress
                           percent={Math.min(Math.round(todayVsGoalPercent), 100)}
                           status={todayVsGoalPercent > 100 ? "exception" : "active"}
-                          strokeColor={todayVsGoalPercent > 100 ? DANGER : ACCENT}
+                          strokeColor={todayVsGoalPercent > 100 ? DANGER : FOREST}
+                          trailColor="#e8efe4"
                           showInfo
                           format={(p) => `${p ?? 0}% of daily goal (today)`}
                         />
@@ -319,19 +469,19 @@ export default function StatsPage() {
                         ) : null}
                       </>
                     ) : (
-                      <Text type="secondary">Set a daily calorie budget to enable comparisons.</Text>
+                      <Text style={{ color: MUTED }}>
+                        Set a daily calorie budget to enable comparisons.
+                      </Text>
                     )}
 
                     {stats?.comparisonToBudget ? (
                       <div>
-                        <Text type="secondary" style={{ fontSize: 12 }}>
-                          Period average vs budget:
-                        </Text>
-                        <div>
+                        <Text style={{ fontSize: 12, color: MUTED }}>Period average vs budget:</Text>
+                        <div style={{ marginTop: 6 }}>
                           <Tag color={comparisonTagColor(stats.comparisonToBudget.status)}>
                             {stats.comparisonToBudget.status.replace(/_/g, " ")}
                           </Tag>
-                          <Text style={{ marginLeft: 8 }}>
+                          <Text style={{ marginLeft: 8, color: "#3d4f3d" }}>
                             Avg {stats.averageDailyCalories.toFixed(0)} vs target{" "}
                             {stats.dailyCalorieTarget?.toFixed(0) ?? "—"} kcal/day
                           </Text>
@@ -343,8 +493,100 @@ export default function StatsPage() {
               </Col>
             </Row>
 
+            <Row gutter={[20, 20]} className={statsStyles.lowerSection}>
+              <Col xs={24} lg={15}>
+                <Card
+                  className={statsStyles.panelCard}
+                  title="Current inventory"
+                  variant="borderless"
+                >
+                  {pantry && pantry.items.length > 0 ? (
+                    <Table<PantryItem>
+                      rowKey="id"
+                      pagination={{ pageSize: 8, showSizeChanger: false }}
+                      size="small"
+                      dataSource={pantry.items}
+                      columns={inventoryColumns}
+                    />
+                  ) : (
+                    <Empty
+                      image={Empty.PRESENTED_IMAGE_SIMPLE}
+                      description="No pantry items yet. Add products from Open Food Facts or your scan flow."
+                    />
+                  )}
+                </Card>
+              </Col>
+              <Col xs={24} lg={9}>
+                <div className={statsStyles.rightStack}>
+                  <Button
+                    type="primary"
+                    className={statsStyles.recordConsumptionBtn}
+                    icon={<RestOutlined />}
+                    onClick={openConsumeModal}
+                  >
+                    Record consumption
+                  </Button>
+
+                  <Card className={`${statsStyles.panelCard} ${statsStyles.activityCard}`} title="Recent activity" variant="borderless">
+                    {activity.length === 0 ? (
+                      <Text type="secondary" style={{ fontSize: 13 }}>
+                        No consumption recorded yet, or logs are still loading.
+                      </Text>
+                    ) : (
+                      <div className={statsStyles.activityList}>
+                        {activity.map((a) => (
+                          <div key={a.id} className={statsStyles.activityItem}>
+                            <div>
+                              <Space size={8}>
+                                <MinusCircleOutlined style={{ color: DANGER }} />
+                                <Text strong style={{ color: "#1b2a1b" }}>
+                                  Consumed {a.consumedQuantity}× {a.productName}
+                                </Text>
+                              </Space>
+                              <div className={statsStyles.activityMeta}>
+                                {dayjs(a.at).format("MMM D, YYYY · HH:mm")}
+                              </div>
+                            </div>
+                            <span className={`${statsStyles.activityDelta} ${statsStyles.deltaNeg}`}>
+                              {Math.round(a.deltaKcal).toLocaleString()} kcal
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </Card>
+
+                  <Card className={statsStyles.insightsCard} variant="borderless">
+                    <div className={statsStyles.insightsTitle}>Inventory insights</div>
+                    <p className={statsStyles.insightsText}>
+                      {estimatedCoverageDays !== null && estimatedCoverageDays > 0 ? (
+                        <>
+                          At your current average consumption rate, pantry calories could last roughly{" "}
+                          <strong>{estimatedCoverageDays}</strong> days before high-calorie staples run low.
+                        </>
+                      ) : (
+                        <>
+                          Add items and keep logging usage to see coverage estimates based on your household
+                          stats.
+                        </>
+                      )}
+                    </p>
+                    <Button
+                      className={statsStyles.insightsBtn}
+                      icon={<ShoppingOutlined />}
+                      onClick={() =>
+                        message.info("Shopping list generation will connect to your inventory in a future iteration.")
+                      }
+                    >
+                      Generate shopping list
+                    </Button>
+                  </Card>
+                </div>
+              </Col>
+            </Row>
+
             {stats ? (
-              <Card title="Daily breakdown" style={{ borderRadius: 12 }}>
+              <Card title="Daily breakdown" className={statsStyles.breakdownCard}>
                 <Table
                   rowKey="date"
                   pagination={false}
@@ -376,8 +618,8 @@ export default function StatsPage() {
         destroyOnClose
       >
         <Paragraph type="secondary">
-          Set the ideal total calories your household aims to consume per day. Only the household
-          owner can change this.
+          Set the ideal total calories your household aims to consume per day. Only the household owner can
+          change this.
         </Paragraph>
         <Form form={budgetForm} layout="vertical">
           <Form.Item
@@ -393,15 +635,59 @@ export default function StatsPage() {
               },
             ]}
           >
+            <InputNumber min={1} max={50000} style={{ width: "100%" }} addonAfter="kcal / day" />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title="Record consumption"
+        open={consumeModalOpen}
+        onCancel={() => setConsumeModalOpen(false)}
+        onOk={() => void submitConsumption()}
+        confirmLoading={consuming}
+        okText="Log consumption"
+        destroyOnClose
+      >
+        <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+          Select an item and how many units you used. Calories are calculated from each item&apos;s
+          kcal per package.
+        </Paragraph>
+        <Form form={consumeForm} layout="vertical">
+          <Form.Item
+            label="Pantry item"
+            name="itemId"
+            rules={[{ required: true, message: "Select an item" }]}
+          >
+            <Select
+              placeholder="Choose item"
+              options={pantry?.items.map((i) => ({
+                value: i.id,
+                label: `${i.name} (${i.count} available)`,
+              }))}
+              onChange={() => consumeForm.setFieldValue("quantity", 1)}
+            />
+          </Form.Item>
+          <Form.Item
+            label="Quantity consumed"
+            name="quantity"
+            rules={[
+              { required: true, message: "Enter quantity" },
+              {
+                type: "number",
+                min: 1,
+                message: "At least 1",
+              },
+            ]}
+          >
             <InputNumber
               min={1}
-              max={50000}
+              max={selectedConsumeItem?.count ?? undefined}
               style={{ width: "100%" }}
-              addonAfter="kcal / day"
             />
           </Form.Item>
         </Form>
       </Modal>
-    </div>
+    </VirtualPantryAppShell>
   );
 }

--- a/app/styles/households.module.css
+++ b/app/styles/households.module.css
@@ -18,8 +18,17 @@
 .brand {
   font-size: 32px;
   font-weight: 700;
-  margin-bottom: 24px;
+  margin-bottom: 6px;
   line-height: 1;
+}
+
+.brandTagline {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #7a8878;
+  margin-bottom: 20px;
 }
 
 .menu {

--- a/app/styles/stats.module.css
+++ b/app/styles/stats.module.css
@@ -1,0 +1,252 @@
+.pageHeader {
+  margin-bottom: 28px;
+}
+
+.pageTitle {
+  margin: 0 0 8px !important;
+  font-size: 42px !important;
+  font-weight: 700 !important;
+  color: #1b2a1b !important;
+  line-height: 1.05 !important;
+}
+
+.pageSubtitle {
+  margin: 0 !important;
+  color: #5d6a5d !important;
+  font-size: 15px !important;
+  max-width: 640px;
+}
+
+.metricGrid {
+  margin-bottom: 28px;
+}
+
+.metricCard {
+  border-radius: 14px !important;
+  border: 1px solid #e2e8d4 !important;
+  background: #ffffff !important;
+  box-shadow: 0 4px 14px rgba(24, 60, 28, 0.06) !important;
+  min-height: 220px;
+  height: 100%;
+}
+
+.metricCard :global(.ant-card-head) {
+  border-bottom: 1px solid #eef2e8 !important;
+  min-height: 52px;
+}
+
+.metricCard :global(.ant-card-head-title) {
+  padding: 12px 0 !important;
+}
+
+.cardTitle {
+  color: #14532d;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.metricLead {
+  color: #5d6a5d;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.metricValue {
+  margin: 0 0 8px !important;
+  font-size: 32px !important;
+  font-weight: 700 !important;
+  color: #1b5e20 !important;
+  line-height: 1.15 !important;
+}
+
+.metricFootnote {
+  font-size: 12px;
+  color: #7a8878;
+}
+
+.lowerSection {
+  margin-bottom: 28px;
+}
+
+.panelCard {
+  border-radius: 14px !important;
+  border: 1px solid #e2e8d4 !important;
+  background: #ffffff !important;
+  box-shadow: 0 4px 14px rgba(24, 60, 28, 0.06) !important;
+  height: 100%;
+}
+
+.panelCard :global(.ant-card-head-title) {
+  font-size: 18px !important;
+  font-weight: 700 !important;
+  color: #1b2a1b !important;
+}
+
+.panelCard :global(.ant-table-thead > tr > th) {
+  background: #f6faf3 !important;
+  color: #3d4f3d !important;
+  font-weight: 600;
+  border-bottom: 1px solid #e5ebe0 !important;
+}
+
+.panelCard :global(.ant-table-tbody > tr > td) {
+  border-bottom: 1px solid #f0f4eb !important;
+}
+
+.categoryTag {
+  text-transform: uppercase;
+  font-size: 11px !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.04em;
+}
+
+.rightStack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+}
+
+.recordConsumptionBtn {
+  width: 100%;
+  min-height: 52px !important;
+  border-radius: 12px !important;
+  font-weight: 700 !important;
+  font-size: 16px !important;
+  background: #1b5e20 !important;
+  border-color: #1b5e20 !important;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.recordConsumptionBtn:hover {
+  background: #14532d !important;
+  border-color: #14532d !important;
+}
+
+.activityCard :global(.ant-card-body) {
+  padding-top: 12px !important;
+}
+
+.activityList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.activityItem {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #e8efe4;
+  background: #fbfcf8;
+}
+
+.activityMeta {
+  font-size: 12px;
+  color: #8a948a;
+  margin-top: 4px;
+}
+
+.activityDelta {
+  font-weight: 700;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.deltaNeg {
+  color: #c62828;
+}
+
+.insightsCard {
+  border-radius: 12px !important;
+  border: none !important;
+  background: linear-gradient(145deg, #1b5e20 0%, #2e7d32 100%) !important;
+  color: #ffffff !important;
+}
+
+.insightsCard :global(.ant-card-body) {
+  padding: 20px !important;
+}
+
+.insightsTitle {
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0 0 10px;
+  letter-spacing: 0.02em;
+}
+
+.insightsText {
+  margin: 0 0 16px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.insightsBtn {
+  width: 100%;
+  border-radius: 10px !important;
+  font-weight: 600 !important;
+  background: #ffffff !important;
+  color: #1b5e20 !important;
+  border: none !important;
+}
+
+.insightsBtn:hover {
+  background: #f1f8e9 !important;
+  color: #14532d !important;
+}
+
+.breakdownCard {
+  border-radius: 14px !important;
+  border: 1px solid #e2e8d4 !important;
+  background: #ffffff !important;
+  box-shadow: 0 4px 14px rgba(24, 60, 28, 0.06) !important;
+}
+
+.breakdownCard :global(.ant-card-head-title) {
+  font-size: 20px !important;
+  font-weight: 700 !important;
+  color: #1b2a1b !important;
+}
+
+.breakdownCard :global(.ant-table) {
+  color: #2d3b2d;
+}
+
+.breakdownCard :global(.ant-table-thead > tr > th) {
+  background: #f6faf3 !important;
+  color: #3d4f3d !important;
+  font-weight: 600;
+  border-bottom: 1px solid #e5ebe0 !important;
+}
+
+.breakdownCard :global(.ant-table-tbody > tr > td) {
+  border-bottom: 1px solid #f0f4eb !important;
+}
+
+.emptyWrap {
+  padding: 48px 24px;
+  text-align: center;
+  border-radius: 14px;
+  border: 1px dashed #cfd9c4;
+  background: #fafdf7;
+  color: #5d6a5d;
+}
+
+.spinCard {
+  border-radius: 14px !important;
+  text-align: center;
+  padding: 48px !important;
+  border: 1px solid #e2e8d4 !important;
+  background: #ffffff !important;
+}

--- a/app/types/budget.ts
+++ b/app/types/budget.ts
@@ -1,0 +1,6 @@
+export interface HouseholdBudget {
+  budgetId: number;
+  householdId: number;
+  dailyCalorieTarget: number;
+  updatedAt?: string | null;
+}

--- a/app/types/consumption.ts
+++ b/app/types/consumption.ts
@@ -1,0 +1,10 @@
+/** GET /households/{householdId}/consumption-logs */
+export interface ConsumptionLogEntry {
+  logId: number;
+  consumedAt: string;
+  pantryItemId: number;
+  productName: string;
+  consumedQuantity: number;
+  consumedCalories: number;
+  userId: number;
+}

--- a/app/types/pantry.ts
+++ b/app/types/pantry.ts
@@ -16,3 +16,10 @@ export interface PantryOverview {
   items: PantryItem[];
   totalCalories: number;
 }
+
+export interface ConsumePantryItemResponse {
+  itemId: number;
+  remainingCount: number;
+  consumedCalories: number;
+  removed: boolean;
+}


### PR DESCRIPTION
## Summary
Pantry **Overview** (`/stats`): calorie metrics, inventory table, **Record consumption** flow, and **Recent activity** loaded from the server consumption-logs API. Shared **Virtual Pantry** shell (sidebar) aligned with households styling.
## Changes
- Pantry Overview layout: metric cards, current inventory table, right column with record consumption + recent activity
- `GET /households/{id}/consumption-logs?limit=30` integrated into dashboard load; activity list matches server logs
- Household cards: **View Pantry** → `/stats`; removed duplicate stats entry where applicable
- Styling: light “organic” palette, removed placeholder shopping-list block per product decision
- Types: `ConsumptionLogEntry`, pantry consume response, etc.
## Depends on
- Backend PR exposing `GET .../consumption-logs` (same release / merge order as server #104)
Refs #104