### PR TITLE
feat: add View Members button and members page

### DIFF
--- a/app/households/[id]/members/page.test.tsx
+++ b/app/households/[id]/members/page.test.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/display-name */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import HouseholdMembersPage from "@/households/[id]/members/page";
+
+const pushMock = jest.fn();
+const getMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useParams: () => ({ id: "10" }),
+  useSearchParams: () => ({ get: (key: string) => (key === "name" ? "Test House" : null) }),
+}));
+
+jest.mock("@/hooks/useApi", () => ({
+  useApi: () => ({ get: getMock }),
+}));
+
+jest.mock("@/hooks/useLocalStorage", () => ({
+  __esModule: true,
+  default: () => ({ value: [], set: jest.fn(), clear: jest.fn() }),
+}));
+
+jest.mock("@/components/VirtualPantryAppShell", () => ({
+  VirtualPantryAppShell: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock("antd", () => {
+  const Button = ({ children, onClick }: any) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  );
+  const Card = ({ children, loading }: any) =>
+    loading ? <div>loading</div> : <div>{children}</div>;
+  const Col = ({ children }: any) => <div>{children}</div>;
+  const Row = ({ children }: any) => <div>{children}</div>;
+  const Tag = ({ children }: any) => <span>{children}</span>;
+  const Typography = {
+    Title: ({ children }: any) => <h1>{children}</h1>,
+    Paragraph: ({ children }: any) => <p>{children}</p>,
+    Text: ({ children }: any) => <span>{children}</span>,
+  };
+  return { Button, Card, Col, Row, Tag, Typography };
+});
+
+const sampleMembers = [
+  { userId: 1, username: "alice", role: "owner", joinedAt: "2026-04-01T10:00:00Z" },
+  { userId: 2, username: "bob", role: "member", joinedAt: "2026-04-05T12:00:00Z" },
+];
+
+describe("HouseholdMembersPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders household name and members on success", async () => {
+    getMock.mockResolvedValueOnce(sampleMembers);
+
+    render(<HouseholdMembersPage />);
+
+    expect(await screen.findByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+    expect(screen.getByText("OWNER")).toBeInTheDocument();
+    expect(screen.getByText("MEMBER")).toBeInTheDocument();
+  });
+
+  it("shows Members (2) count after loading", async () => {
+    getMock.mockResolvedValueOnce(sampleMembers);
+
+    render(<HouseholdMembersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Members \(2\)/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when API call fails", async () => {
+    getMock.mockRejectedValueOnce(new Error("forbidden"));
+
+    render(<HouseholdMembersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("forbidden")).toBeInTheDocument();
+    });
+  });
+
+  it("shows no members message when list is empty", async () => {
+    getMock.mockResolvedValueOnce([]);
+
+    render(<HouseholdMembersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No members found.")).toBeInTheDocument();
+    });
+  });
+
+  it("Back button navigates to /households", async () => {
+    getMock.mockResolvedValueOnce(sampleMembers);
+
+    render(<HouseholdMembersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to households" }));
+    expect(pushMock).toHaveBeenCalledWith("/households");
+  });
+});

--- a/app/households/[id]/members/page.tsx
+++ b/app/households/[id]/members/page.tsx
@@ -43,6 +43,12 @@ export default function HouseholdMembersPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!Number.isFinite(householdId) || householdId <= 0) {
+      setErrorMessage("Invalid household ID.");
+      setIsLoading(false);
+      return;
+    }
+
     const fetchMembers = async () => {
       setIsLoading(true);
       setErrorMessage(null);

--- a/app/households/[id]/members/page.tsx
+++ b/app/households/[id]/members/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useApi } from "@/hooks/useApi";
+import useLocalStorage from "@/hooks/useLocalStorage";
+import type { HouseholdWithRole } from "@/types/household";
+import { VirtualPantryAppShell } from "@/components/VirtualPantryAppShell";
+import { Button, Col, Row, Tag, Typography } from "antd";
+import styles from "@/styles/households.module.css";
+
+const { Title, Paragraph } = Typography;
+
+interface HouseholdMember {
+  userId: number;
+  username: string;
+  role: "owner" | "member";
+  joinedAt: string;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString();
+}
+
+export default function HouseholdMembersPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const searchParams = useSearchParams();
+  const api = useApi();
+
+  const { value: cachedHouseholds } = useLocalStorage<HouseholdWithRole[]>("households", []);
+  const householdId = Number(params.id);
+
+  const householdName = useMemo(() => {
+    const queryName = searchParams.get("name");
+    if (queryName?.trim()) return queryName.trim();
+    return cachedHouseholds.find((h) => h.householdId === householdId)?.name ?? `Household ${householdId}`;
+  }, [searchParams, cachedHouseholds, householdId]);
+
+  const [members, setMembers] = useState<HouseholdMember[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchMembers = async () => {
+      setIsLoading(true);
+      setErrorMessage(null);
+      try {
+        const data = await api.get<HouseholdMember[]>(`/households/${householdId}/members`);
+        setMembers(data);
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : "Failed to load members.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void fetchMembers();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [householdId]);
+
+  return (
+    <VirtualPantryAppShell activeNav="households">
+      <div className={styles.header}>
+        <div>
+          <Title level={1} className={styles.title}>{householdName}</Title>
+          <Paragraph className={styles.subtitle}>Members of this household</Paragraph>
+        </div>
+        <Button onClick={() => router.push("/households")}>Back to households</Button>
+      </div>
+
+      <section className={styles.section}>
+        <Title level={3} className={styles.sectionTitle}>
+          Members ({isLoading ? "…" : members.length})
+        </Title>
+
+        {errorMessage && (
+          <div className={styles.joinInfoBox} style={{ borderColor: "#f5c6cb", background: "#fff5f5", color: "#c0392b" }}>
+            {errorMessage}
+          </div>
+        )}
+
+        {!isLoading && members.length === 0 && !errorMessage && (
+          <Paragraph type="secondary">No members found.</Paragraph>
+        )}
+
+        <Row gutter={[12, 12]}>
+          {members.map((member) => (
+            <Col xs={24} sm={12} md={8} lg={6} key={member.userId}>
+              <div className={styles.householdCard} style={{ padding: 12, minHeight: "auto" }}>
+                <Tag
+                  color={member.role === "owner" ? "green" : "blue"}
+                  style={{ marginBottom: 6 }}
+                >
+                  {member.role.toUpperCase()}
+                </Tag>
+                <div style={{ fontWeight: 600, fontSize: 15 }}>{member.username}</div>
+                <p className={styles.householdMeta} style={{ marginBottom: 0, marginTop: 4 }}>
+                  Joined: {formatDate(member.joinedAt)}
+                </p>
+              </div>
+            </Col>
+          ))}
+        </Row>
+      </section>
+    </VirtualPantryAppShell>
+  );
+}

--- a/app/households/page.test.tsx
+++ b/app/households/page.test.tsx
@@ -269,4 +269,23 @@ describe("Households page", () => {
     expect(warningMock).toHaveBeenCalledWith("Please enter a household name.");
     expect(warningMock).toHaveBeenCalledWith("Please enter an invite code.");
   });
+
+  it("View Members navigates to the members page with encoded household name", () => {
+    mockStoredHouseholds = [
+      {
+        householdId: 10,
+        name: "Test House",
+        inviteCode: "ABC123",
+        ownerId: 1,
+        role: "owner",
+      },
+    ];
+
+    render(<HouseholdsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /View Members/i }));
+    expect(pushMock).toHaveBeenCalledWith(
+      "/households/10/members?name=Test%20House",
+    );
+  });
 });

--- a/app/households/page.tsx
+++ b/app/households/page.tsx
@@ -38,7 +38,6 @@ export default function HouseholdsPage() {
     set: setHouseholds,
   } = useLocalStorage<HouseholdWithRole[]>("households", []);
   const {
-    value: selectedHouseholdId,
     set: setSelectedHouseholdId,
   } = useLocalStorage<number | null>("selectedHouseholdId", null);
 

--- a/app/households/page.tsx
+++ b/app/households/page.tsx
@@ -275,6 +275,11 @@ export default function HouseholdsPage() {
                       <Button className={styles.outlineButton} onClick={() => handleOpenPantry(household)}>
                         View Pantry
                       </Button>
+                      <Button
+                        onClick={() => router.push(`/households/${household.householdId}/members?name=${encodeURIComponent(household.name)}`)}
+                      >
+                        View Members
+                      </Button>
                     </Space>
                   </Card>
                 </Col>

--- a/app/open-food-facts/page.test.tsx
+++ b/app/open-food-facts/page.test.tsx
@@ -183,7 +183,6 @@ describe("Debug portal page", () => {
 
 describe("Receipt image upload in the debug portal", () => {
   const originalCreateObjectURL = URL.createObjectURL;
-  const originalRevokeObjectURL = URL.revokeObjectURL;
 
   beforeEach(() => {
     postFormDataMock.mockReset();
@@ -193,7 +192,6 @@ describe("Receipt image upload in the debug portal", () => {
 
   afterEach(() => {
     URL.createObjectURL = originalCreateObjectURL;
-    URL.revokeObjectURL = originalRevokeObjectURL;
   });
 
   it("shows a local preview after selecting a receipt image", () => {

--- a/app/open-food-facts/page.test.tsx
+++ b/app/open-food-facts/page.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/display-name */
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import OpenFoodFactsPage from "./page";


### PR DESCRIPTION
## Summary
- Add View Members button to each household card on the My Households page
- New page /households/[id]/members showing all members with username, role, and join date

Closes #48