### PR TITLE
fix: simplify auth flow and fix pantry navigation

### DIFF
--- a/app/api/apiService.test.ts
+++ b/app/api/apiService.test.ts
@@ -1,12 +1,9 @@
 import { ApiService } from "@/api/apiService";
 import { ApplicationError } from "@/types/error";
-import { navigateTo } from "@/utils/navigate";
 
 jest.mock("@/utils/domain", () => ({
   getApiDomain: () => "http://localhost:8080",
 }));
-
-jest.mock("@/utils/navigate");
 
 describe("ApiService", () => {
   const fetchMock = jest.fn();
@@ -132,7 +129,7 @@ describe("ApiService", () => {
     );
   });
 
-  it("clears token and redirects to login on 401", async () => {
+  it("throws ApplicationError with backend details on 401", async () => {
     sessionStorage.setItem("token", JSON.stringify("stored-token"));
     fetchMock.mockResolvedValue({
       ok: false,
@@ -143,11 +140,11 @@ describe("ApiService", () => {
     });
 
     const api = new ApiService();
-    void api.get("/households/10/pantry");
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(sessionStorage.getItem("token")).toBeNull();
-    expect(navigateTo).toHaveBeenCalledWith("/login?reason=session_expired");
+    await expect(api.get("/households/10/pantry")).rejects.toMatchObject({
+      status: 401,
+      message: expect.stringContaining("Invalid token"),
+    } satisfies Partial<ApplicationError>);
+    expect(sessionStorage.getItem("token")).not.toBeNull();
   });
 
   it("throws ApplicationError with backend details on non-401 failure", async () => {

--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -1,8 +1,5 @@
 import { getApiDomain } from "@/utils/domain";
 import { ApplicationError } from "@/types/error";
-import { navigateTo } from "@/utils/navigate";
-
-let isRedirectingToLogin = false;
 
 export class ApiService {
   private baseURL: string;
@@ -36,20 +33,6 @@ export class ApiService {
     errorMessage: string,
   ): Promise<T> {
     if (!res.ok) {
-      if (res.status === 401 && typeof window !== "undefined") {
-        if (isRedirectingToLogin) {
-          return new Promise<never>(() => {});
-        }
-        const hadToken = sessionStorage.getItem("token") !== null;
-        sessionStorage.removeItem("token");
-        sessionStorage.removeItem("username");
-        if (hadToken) {
-          isRedirectingToLogin = true;
-          navigateTo("/login?reason=session_expired");
-          return new Promise<never>(() => {});
-        }
-      }
-
       let errorDetail = res.statusText;
       try {
         const errorInfo = await res.json();

--- a/app/components/VirtualPantryAppShell.tsx
+++ b/app/components/VirtualPantryAppShell.tsx
@@ -43,8 +43,11 @@ export function VirtualPantryAppShell({ activeNav, children }: VirtualPantryAppS
       households.some((h) => h.householdId === selectedHouseholdId)
         ? selectedHouseholdId
         : households[0].householdId;
+    const household = households.find((h) => h.householdId === id);
     setSelectedHouseholdId(id);
-    router.push("/stats");
+    router.push(
+      `/households/${id}?name=${encodeURIComponent(household?.name ?? `Household ${id}`)}`,
+    );
   };
 
   const handleLogout = () => {

--- a/app/hooks/useSessionStorage.tsx
+++ b/app/hooks/useSessionStorage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const SYNC_EVENT = "sessionstorage-sync";
 
@@ -47,7 +47,7 @@ export default function useSessionStorage<T>(
     };
   }, [key]);
 
-  const set = (newVal: T) => {
+  const set = useCallback((newVal: T) => {
     setValue(newVal);
     if (typeof window !== "undefined") {
       const serialized = JSON.stringify(newVal);
@@ -56,9 +56,9 @@ export default function useSessionStorage<T>(
         new CustomEvent(SYNC_EVENT, { detail: { key, value: serialized } }),
       );
     }
-  };
+  }, [key]);
 
-  const clear = () => {
+  const clear = useCallback(() => {
     setValue(defaultValueRef.current);
     if (typeof window !== "undefined") {
       globalThis.sessionStorage.removeItem(key);
@@ -66,7 +66,7 @@ export default function useSessionStorage<T>(
         new CustomEvent(SYNC_EVENT, { detail: { key, value: null } }),
       );
     }
-  };
+  }, [key]);
 
   return { value, set, clear };
 }

--- a/app/households/page.test.tsx
+++ b/app/households/page.test.tsx
@@ -162,14 +162,14 @@ describe("Households page", () => {
     expect(pushMock).not.toHaveBeenCalled();
   });
 
-  it("sidebar Pantry navigates to calorie dashboard when a household exists", () => {
+  it("sidebar Pantry navigates to the selected household pantry when a household exists", () => {
     mockStoredHouseholds = [
       { householdId: 7, name: "Home", inviteCode: "ABC", ownerId: 1, role: "owner" },
     ];
     render(<HouseholdsPage />);
     fireEvent.click(screen.getByText("Pantry").closest("button") as HTMLButtonElement);
     expect(setSelectedHouseholdIdMock).toHaveBeenCalledWith(7);
-    expect(pushMock).toHaveBeenCalledWith("/stats");
+    expect(pushMock).toHaveBeenCalledWith("/households/7?name=Home");
   });
 
   it("creates a household and stores it in local storage", async () => {
@@ -248,7 +248,7 @@ describe("Households page", () => {
     });
   });
 
-  it("View Pantry opens the calorie dashboard for a stored household", () => {
+  it("View Pantry opens the pantry page for a stored household", () => {
     mockStoredHouseholds = [
       {
         householdId: 10,
@@ -263,7 +263,7 @@ describe("Households page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /View Pantry/i }));
     expect(setSelectedHouseholdIdMock).toHaveBeenCalledWith(10);
-    expect(pushMock).toHaveBeenCalledWith("/stats");
+    expect(pushMock).toHaveBeenCalledWith("/households/10?name=Test%20House");
   });
 
   it("shows warning for empty inputs", () => {

--- a/app/households/page.tsx
+++ b/app/households/page.tsx
@@ -160,7 +160,9 @@ export default function HouseholdsPage() {
 
   const handleOpenPantry = (household: HouseholdWithRole) => {
     setSelectedHouseholdId(household.householdId);
-    router.push("/stats");
+    router.push(
+      `/households/${household.householdId}?name=${encodeURIComponent(household.name)}`,
+    );
   };
 
   const activeInvites = households.filter((household) => household.role === "owner").length;

--- a/app/login/page.test.tsx
+++ b/app/login/page.test.tsx
@@ -7,6 +7,8 @@ const replaceMock = jest.fn();
 const postMock = jest.fn();
 const getMock = jest.fn();
 const setTokenMock = jest.fn();
+const clearTokenMock = jest.fn(() => sessionStorage.removeItem("token"));
+const clearUsernameMock = jest.fn(() => sessionStorage.removeItem("username"));
 const messageMock = { warning: jest.fn(), error: jest.fn(), success: jest.fn() };
 
 jest.mock("antd", () => {
@@ -66,7 +68,11 @@ jest.mock("@/hooks/useApi", () => ({
 
 jest.mock("@/hooks/useSessionStorage", () => ({
   __esModule: true,
-  default: () => ({ set: setTokenMock, clear: jest.fn(), value: "" }),
+  default: (key: string) => {
+    if (key === "token") return { set: setTokenMock, clear: clearTokenMock, value: "" };
+    if (key === "username") return { set: jest.fn(), clear: clearUsernameMock, value: "" };
+    return { set: jest.fn(), clear: jest.fn(), value: "" };
+  },
 }));
 
 jest.mock("@/hooks/useLocalStorage", () => ({

--- a/app/login/page.test.tsx
+++ b/app/login/page.test.tsx
@@ -3,7 +3,9 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import Login from "@/login/page";
 
 const pushMock = jest.fn();
+const replaceMock = jest.fn();
 const postMock = jest.fn();
+const getMock = jest.fn();
 const setTokenMock = jest.fn();
 const messageMock = { warning: jest.fn(), error: jest.fn(), success: jest.fn() };
 
@@ -54,12 +56,12 @@ jest.mock("antd", () => {
 });
 
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: pushMock }),
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
   useSearchParams: () => ({ get: () => null }),
 }));
 
 jest.mock("@/hooks/useApi", () => ({
-  useApi: () => ({ post: postMock, get: jest.fn().mockResolvedValue([]) }),
+  useApi: () => ({ post: postMock, get: getMock }),
 }));
 
 jest.mock("@/hooks/useSessionStorage", () => ({
@@ -75,6 +77,8 @@ jest.mock("@/hooks/useLocalStorage", () => ({
 describe("Login page", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear();
+    getMock.mockResolvedValue([]);
     globalThis.alert = jest.fn();
   });
 
@@ -82,6 +86,42 @@ describe("Login page", () => {
     render(<Login />);
     expect(screen.getByRole("heading", { name: "Welcome Back" })).toBeInTheDocument();
     expect(screen.getAllByRole("button")[0]).toBeInTheDocument();
+  });
+
+  it("redirects to households when existing token is valid", async () => {
+    sessionStorage.setItem("token", JSON.stringify("valid-token"));
+    getMock.mockResolvedValueOnce([]);
+
+    render(<Login />);
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith("/households");
+      expect(replaceMock).toHaveBeenCalledWith("/households");
+    });
+  });
+
+  it("clears token and stays on login when existing token returns 401", async () => {
+    sessionStorage.setItem("token", JSON.stringify("expired-token"));
+    getMock.mockRejectedValueOnce({ status: 401 });
+
+    render(<Login />);
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem("token")).toBeNull();
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keeps token and stays on login when server error occurs", async () => {
+    sessionStorage.setItem("token", JSON.stringify("valid-token"));
+    getMock.mockRejectedValueOnce({ status: 500 });
+
+    render(<Login />);
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem("token")).not.toBeNull();
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
   });
 
   it("submits credentials and navigates on success", async () => {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -23,18 +23,23 @@ const Login: React.FC = () => {
   const apiService = useApi();
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    if (params.get("reason") === "session_expired") {
-      message.warning("Your session has expired. Please log in again. If login fails, your account may no longer exist, please register.");
-      return;
-    }
+    let token: string | null = null;
     try {
-      const token = JSON.parse(sessionStorage.getItem("token") ?? "null") as string | null;
-      if (token) router.replace("/households");
+      token = JSON.parse(sessionStorage.getItem("token") ?? "null") as string | null;
     } catch {
-      // malformed token, stay on login
+      // malformed token
     }
-  }, [message, router]);
+    if (!token) return;
+
+    apiService.get("/households")
+      .then(() => router.replace("/households"))
+      .catch((error: unknown) => {
+        if ((error as { status?: number })?.status === 401) {
+          sessionStorage.removeItem("token");
+          sessionStorage.removeItem("username");
+        }
+      });
+  }, [apiService, router]);
   const [form] = Form.useForm<LoginFormValues>();
   const { set: setToken } = useSessionStorage<string>("token", "");
   const { set: setUsername } = useSessionStorage<string>("username", "");

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -21,6 +21,10 @@ const Login: React.FC = () => {
   const router = useRouter();
   const { message } = App.useApp();
   const apiService = useApi();
+  const [form] = Form.useForm<LoginFormValues>();
+  const { set: setToken, clear: clearToken } = useSessionStorage<string>("token", "");
+  const { set: setUsername, clear: clearUsername } = useSessionStorage<string>("username", "");
+  const { set: setHouseholds } = useLocalStorage<HouseholdWithRole[]>("households", []);
 
   useEffect(() => {
     let token: string | null = null;
@@ -35,15 +39,11 @@ const Login: React.FC = () => {
       .then(() => router.replace("/households"))
       .catch((error: unknown) => {
         if ((error as { status?: number })?.status === 401) {
-          sessionStorage.removeItem("token");
-          sessionStorage.removeItem("username");
+          clearToken();
+          clearUsername();
         }
       });
-  }, [apiService, router]);
-  const [form] = Form.useForm<LoginFormValues>();
-  const { set: setToken } = useSessionStorage<string>("token", "");
-  const { set: setUsername } = useSessionStorage<string>("username", "");
-  const { set: setHouseholds } = useLocalStorage<HouseholdWithRole[]>("households", []);
+  }, [apiService, router, clearToken, clearUsername]);
 
   const handleLogin = async (values: LoginFormValues): Promise<void> => {
     try {

--- a/app/open-food-facts/page.tsx
+++ b/app/open-food-facts/page.tsx
@@ -109,7 +109,7 @@ export default function OpenFoodFactsPortalPage() {
       </Card>
 
       <Card title="Barcode lookup" className={styles.sectionCard}>
-        <Space direction="vertical" size="large" style={{ width: "100%" }}>
+        <Space orientation="vertical" size="large" style={{ width: "100%" }}>
           <div className={styles.lookupStack}>
             <label className={styles.lookupLabel}>
               <span>Barcode</span>


### PR DESCRIPTION
## Summary
- Remove auto-redirect on 401 from `apiService`; 401 is now thrown as a normal error like any other HTTP error
- Login page validates existing token via `GET /households` before auto-redirecting; clears token only on 401 (not network/server errors)
- Pantry sidebar button and "View Pantry" now navigate to `/households/:id` instead of `/stats`
- Replace deprecated antd `Space` `direction` prop with `orientation`

## Test plan
- [ ] Fresh login with correct credentials → navigates to households
- [ ] Login with wrong credentials → shows "Username or password is incorrect"
- [ ] Login with stale token (server restarted) → token cleared, stays on login page
- [ ] Already logged in → opening login page redirects to households
- [ ] Pantry sidebar button → navigates to correct household page
- [ ] All 90 tests pass, build succeeds