### PR TITLE
Yifu/general debug.04.24

### DIFF
--- a/app/households/[id]/stats/page.test.tsx
+++ b/app/households/[id]/stats/page.test.tsx
@@ -5,6 +5,7 @@ import StatsPage from "@/households/[id]/stats/page";
 const pushMock = jest.fn();
 const getMock = jest.fn();
 const putMock = jest.fn();
+const postMock = jest.fn();
 const messageMock = {
   warning: jest.fn(),
   error: jest.fn(),
@@ -27,7 +28,7 @@ jest.mock("@/components/VirtualPantryAppShell", () => ({
 }));
 
 jest.mock("@/hooks/useApi", () => ({
-  useApi: () => ({ get: getMock, put: putMock }),
+  useApi: () => ({ get: getMock, put: putMock, post: postMock }),
 }));
 
 jest.mock("@/hooks/useSessionStorage", () => ({
@@ -64,10 +65,12 @@ jest.mock("@/hooks/useLocalStorage", () => ({
 
 jest.mock("@ant-design/icons", () => ({
   ArrowLeftOutlined: () => <span data-testid="arrow-left-icon" />,
+  BarcodeOutlined: () => <span data-testid="barcode-icon" />,
   EditOutlined: () => <span data-testid="edit-icon" />,
   WarningOutlined: () => <span data-testid="warn-icon" />,
   RestOutlined: () => <span data-testid="rest-icon" />,
   MinusCircleOutlined: () => <span data-testid="minus-icon" />,
+  PlusCircleOutlined: () => <span data-testid="plus-icon" />,
 }));
 
 jest.mock("antd", () => {
@@ -92,17 +95,21 @@ jest.mock("antd", () => {
   const Empty = ({ description, children }: any) => <div>{description}{children}</div>;
   Empty.PRESENTED_IMAGE_SIMPLE = "simple";
   const Tag = ({ children }: any) => <span>{children}</span>;
-  const Table = ({ dataSource, rowKey }: any) => (
-    <table>
-      <tbody>
-        {dataSource?.map((row: any, i: number) => (
-          <tr key={row[rowKey] ?? row.date ?? i}>
-            <td>{row.date ?? row.name ?? ""}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
+  const Table = ({ dataSource, rowKey, columns }: any) => {
+    const actionColumn = columns?.find((column: any) => column.key === "action");
+    return (
+      <table>
+        <tbody>
+          {dataSource?.map((row: any, i: number) => (
+            <tr key={row[rowKey] ?? row.date ?? i}>
+              <td>{row.date ?? row.name ?? ""}</td>
+              {actionColumn ? <td>{actionColumn.render(undefined, row, i)}</td> : null}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  };
   const Select = () => <div data-testid="select" />;
   const DatePicker = ({ onChange }: any) => (
     <input
@@ -174,10 +181,17 @@ jest.mock("antd", () => {
 describe("StatsPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    postMock.mockResolvedValue({ itemId: 1, remainingCount: 2, consumedCalories: 120, removed: false });
     getMock.mockImplementation((url: string) => {
       const today = new Date().toISOString().slice(0, 10);
       if (url.includes("/pantry")) {
-        return Promise.resolve({ items: [{ id: 1 }, { id: 2 }], totalCalories: 142500 });
+        return Promise.resolve({
+          items: [
+            { id: 1, householdId: 1, barcode: "111", name: "Milk", quantity: 1, count: 3, kcalPerPackage: 120, addedAt: "2026-04-01T00:00:00Z" },
+            { id: 2, householdId: 1, barcode: "222", name: "Rice", quantity: 1, count: 5, kcalPerPackage: 300, addedAt: "2026-04-01T00:00:00Z" },
+          ],
+          totalCalories: 142500,
+        });
       }
       if (url.includes("/stats")) {
         return Promise.resolve({
@@ -202,7 +216,17 @@ describe("StatsPage", () => {
         });
       }
       if (url.includes("/consumption-logs")) {
-        return Promise.resolve([]);
+        return Promise.resolve([
+          {
+            logId: 9,
+            consumedAt: "2026-04-02T00:00:00Z",
+            pantryItemId: 1,
+            productName: "Milk",
+            consumedQuantity: 1,
+            consumedCalories: 120,
+            userId: 99,
+          },
+        ]);
       }
       return Promise.reject(new Error(`unexpected ${url}`));
     });
@@ -260,6 +284,25 @@ describe("StatsPage", () => {
     );
   });
 
+  it("navigates to scan product page with household context when scan button clicked", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/pantry")) return Promise.resolve({ items: [], totalCalories: 0 });
+      if (url.includes("/stats")) return Promise.resolve({ startDate: "2026-04-07", endDate: "2026-04-19", dailyCalorieTarget: null, averageDailyCalories: 0, totalCaloriesConsumed: 0, dailyBreakdown: [], comparisonToBudget: null });
+      if (url.includes("/budget")) return Promise.reject(new Error("no budget"));
+      if (url.includes("/consumption-logs")) return Promise.resolve([]);
+      return Promise.reject(new Error(`unexpected ${url}`));
+    });
+
+    render(<StatsPage />);
+
+    const scanBtn = await screen.findByRole("button", { name: /Scan product/i });
+    fireEvent.click(scanBtn);
+
+    expect(pushMock).toHaveBeenCalledWith(
+      expect.stringContaining("/pantry/add/scan?householdId=1"),
+    );
+  });
+
   it("opens budget modal when owner clicks Edit", async () => {
     render(<StatsPage />);
 
@@ -273,4 +316,40 @@ describe("StatsPage", () => {
       expect(screen.getByTestId("budget-modal")).toBeInTheDocument();
     });
   });
+
+
+  it("shows added and consumed rows in recent activity", async () => {
+    render(<StatsPage />);
+
+    expect(await screen.findByText(/Added 3× Milk/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Consumed 1× Milk/i)).toBeInTheDocument();
+  });
+
+  it("consumes one unit from the selected inventory row", async () => {
+    render(<StatsPage />);
+
+    const consumeButtons = await screen.findAllByRole("button", { name: /Consume/i });
+    fireEvent.click(consumeButtons[0]);
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith("/households/1/pantry/1/consume", { quantity: 1 });
+    });
+
+    expect(messageMock.success).toHaveBeenCalledWith("Consumption recorded.");
+  });
+
+  it("removes one unit from the selected inventory row without recording consumption", async () => {
+    render(<StatsPage />);
+
+    const removeButtons = await screen.findAllByRole("button", { name: /Remove/i });
+    fireEvent.click(removeButtons[0]);
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith("/households/1/pantry/1/remove", { quantity: 1 });
+    });
+
+    expect(postMock).not.toHaveBeenCalledWith("/households/1/pantry/1/consume", { quantity: 1 });
+    expect(messageMock.success).toHaveBeenCalledWith("One unit removed from pantry.");
+  });
+
 });

--- a/app/households/[id]/stats/page.tsx
+++ b/app/households/[id]/stats/page.tsx
@@ -24,6 +24,7 @@ import {
   ArrowLeftOutlined,
   EditOutlined,
   MinusCircleOutlined,
+  PlusCircleOutlined,
   RestOutlined,
   WarningOutlined,
 } from "@ant-design/icons";
@@ -53,17 +54,38 @@ type ActivityEntry = {
   at: string;
   productName: string;
   deltaKcal: number;
-  consumedQuantity: number;
+  quantity: number;
+  type: "ADDED" | "CONSUMED";
 };
 
 function logsToActivity(logs: ConsumptionLogEntry[]): ActivityEntry[] {
   return logs.map((log) => ({
-    id: `log-${log.logId}`,
+    id: `consume-${log.logId}`,
     at: log.consumedAt,
     productName: log.productName,
     deltaKcal: -log.consumedCalories,
-    consumedQuantity: log.consumedQuantity,
+    quantity: log.consumedQuantity,
+    type: "CONSUMED",
   }));
+}
+
+function pantryItemsToActivity(items: PantryItem[]): ActivityEntry[] {
+  return items
+    .filter((item) => Boolean(item.addedAt))
+    .map((item) => ({
+      id: `add-${item.id}`,
+      at: item.addedAt,
+      productName: item.name,
+      deltaKcal: item.kcalPerPackage * item.count,
+      quantity: item.count,
+      type: "ADDED",
+    }));
+}
+
+function buildRecentActivity(items: PantryItem[], logs: ConsumptionLogEntry[]): ActivityEntry[] {
+  return [...pantryItemsToActivity(items), ...logsToActivity(logs)]
+    .sort((a, b) => dayjs(b.at).valueOf() - dayjs(a.at).valueOf())
+    .slice(0, 30);
 }
 
 function isNotFound(error: unknown): boolean {
@@ -162,7 +184,7 @@ export default function StatsPage() {
       ]);
       setPantry(pantryRes);
       setStats(statsRes);
-      setActivity(logsToActivity(logsRes));
+      setActivity(buildRecentActivity(pantryRes.items, logsRes));
 
       try {
         const b = await api.get<HouseholdBudget>(`/households/${householdId}/budget`);
@@ -529,72 +551,91 @@ export default function StatsPage() {
             </Row>
 
             <Row gutter={[20, 20]} className={statsStyles.lowerSection}>
-              <Col xs={24} lg={15}>
-                <Card
-                  className={statsStyles.panelCard}
-                  title="Current inventory"
-                  extra={
-                    <Button
-                      type="primary"
-                      size="small"
-                      onClick={() =>
-                        router.push(
-                          `/open-food-facts?householdId=${householdId}&householdName=${encodeURIComponent(householdName)}`,
-                        )
-                      }
-                    >
-                      Add from Open Food Facts
-                    </Button>
-                  }
-                  variant="borderless"
-                >
-                  {pantry && pantry.items.length > 0 ? (
-                    <Table<PantryItem>
-                      rowKey="id"
-                      pagination={{ pageSize: 8, showSizeChanger: false }}
-                      size="small"
-                      dataSource={pantry.items}
-                      columns={inventoryColumns}
-                    />
-                  ) : (
-                    <Empty
-                      image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description="No pantry items yet."
-                    />
-                  )}
-                </Card>
-              </Col>
-              <Col xs={24} lg={9}>
-                <div className={statsStyles.rightStack}>
+              <Col xs={24}>
+                <Space direction="vertical" size="large" style={{ width: "100%" }}>
+                  <Card
+                    className={statsStyles.panelCard}
+                    title="Current inventory"
+                    extra={
+                      <Space size="small" wrap>
+                        <Button
+                          type="primary"
+                          size="small"
+                          onClick={() =>
+                            router.push(
+                              `/pantry/add/scan?householdId=${householdId}&householdName=${encodeURIComponent(householdName)}`,
+                            )
+                          }
+                        >
+                          Scan product barcode
+                        </Button>
+                        <Button
+                          type="primary"
+                          size="small"
+                          onClick={() =>
+                            router.push(
+                              `/open-food-facts?householdId=${householdId}&householdName=${encodeURIComponent(householdName)}`,
+                            )
+                          }
+                        >
+                          Add from Open Food Facts
+                        </Button>
+                      </Space>
+                    }
+                    variant="borderless"
+                  >
+                    {pantry && pantry.items.length > 0 ? (
+                      <Table<PantryItem>
+                        rowKey="id"
+                        pagination={{ pageSize: 8, showSizeChanger: false }}
+                        size="small"
+                        dataSource={pantry.items}
+                        columns={inventoryColumns}
+                      />
+                    ) : (
+                      <Empty
+                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                        description="No pantry items yet."
+                      />
+                    )}
+                  </Card>
+
                   <Card className={`${statsStyles.panelCard} ${statsStyles.activityCard}`} title="Recent activity" variant="borderless">
                     {activity.length === 0 ? (
                       <Text type="secondary" style={{ fontSize: 13 }}>
-                        No consumption recorded yet, or logs are still loading.
+                        No pantry activity recorded yet, or logs are still loading.
                       </Text>
                     ) : (
                       <div className={statsStyles.activityList}>
-                        {activity.map((a) => (
-                          <div key={a.id} className={statsStyles.activityItem}>
-                            <div>
-                              <Space size={8}>
-                                <MinusCircleOutlined style={{ color: DANGER }} />
-                                <Text strong style={{ color: "#1b2a1b" }}>
-                                  Consumed {a.consumedQuantity}× {a.productName}
-                                </Text>
-                              </Space>
-                              <div className={statsStyles.activityMeta}>
-                                {dayjs(a.at).format("MMM D, YYYY · HH:mm")}
+                        {activity.map((a) => {
+                          const isAdded = a.type === "ADDED";
+                          return (
+                            <div key={a.id} className={statsStyles.activityItem}>
+                              <div>
+                                <Space size={8}>
+                                  {isAdded ? (
+                                    <PlusCircleOutlined style={{ color: FOREST }} />
+                                  ) : (
+                                    <MinusCircleOutlined style={{ color: DANGER }} />
+                                  )}
+                                  <Text strong style={{ color: "#1b2a1b" }}>
+                                    {isAdded ? "Added" : "Consumed"} {a.quantity}× {a.productName}
+                                  </Text>
+                                </Space>
+                                <div className={statsStyles.activityMeta}>
+                                  {dayjs(a.at).format("MMM D, YYYY · HH:mm")}
+                                </div>
                               </div>
+                              <span className={`${statsStyles.activityDelta} ${isAdded ? statsStyles.deltaPos : statsStyles.deltaNeg}`}>
+                                {isAdded ? "+" : ""}{Math.round(a.deltaKcal).toLocaleString()} kcal
+                              </span>
                             </div>
-                            <span className={`${statsStyles.activityDelta} ${statsStyles.deltaNeg}`}>
-                              {Math.round(a.deltaKcal).toLocaleString()} kcal
-                            </span>
-                          </div>
-                        ))}
+                          );
+                        })}
                       </div>
                     )}
                   </Card>
-                </div>
+                </Space>
               </Col>
             </Row>
 

--- a/app/households/[id]/stats/page.tsx
+++ b/app/households/[id]/stats/page.tsx
@@ -161,6 +161,7 @@ export default function StatsPage() {
   const [budgetForm] = Form.useForm<{ dailyCalorieTarget: number }>();
 
   const [consumingItemId, setConsumingItemId] = useState<number | null>(null);
+  const [removingItemId, setRemovingItemId] = useState<number | null>(null);
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
 
   const loadDashboard = useCallback(async () => {
@@ -312,6 +313,39 @@ export default function StatsPage() {
     [api, householdId, loadDashboard, message],
   );
 
+
+  const removeInventoryItem = useCallback(
+    async (item: PantryItem) => {
+      if (!item.id) {
+        message.error("Selected item is missing an item ID.");
+        return;
+      }
+      if (!item.count || item.count <= 0) {
+        message.error("This item is no longer available in the pantry.");
+        return;
+      }
+
+      setRemovingItemId(item.id);
+      try {
+        const res = await api.post<ConsumePantryItemResponse>(
+          `/households/${householdId}/pantry/${item.id}/remove`,
+          { quantity: 1 },
+        );
+        message.success(
+          res.removed
+            ? "Item removed from pantry."
+            : "One unit removed from pantry.",
+        );
+        await loadDashboard();
+      } catch (error) {
+        message.error(error instanceof Error ? error.message : "Could not remove item from pantry.");
+      } finally {
+        setRemovingItemId(null);
+      }
+    },
+    [api, householdId, loadDashboard, message],
+  );
+
   const inventoryColumns: TableProps<PantryItem>["columns"] = useMemo(
     () => [
       {
@@ -369,22 +403,33 @@ export default function StatsPage() {
       {
         title: "Action",
         key: "action",
-        width: 130,
+        width: 220,
         render: (_: unknown, record: PantryItem) => (
-          <Button
-            type="primary"
-            size="small"
-            icon={<RestOutlined />}
-            loading={consumingItemId === record.id}
-            disabled={Boolean(consumingItemId) || record.count <= 0}
-            onClick={() => void consumeInventoryItem(record)}
-          >
-            Consume
-          </Button>
+          <Space size="small" wrap>
+            <Button
+              type="primary"
+              size="small"
+              icon={<RestOutlined />}
+              loading={consumingItemId === record.id}
+              disabled={Boolean(consumingItemId) || Boolean(removingItemId) || record.count <= 0}
+              onClick={() => void consumeInventoryItem(record)}
+            >
+              Consume
+            </Button>
+            <Button
+              size="small"
+              danger
+              loading={removingItemId === record.id}
+              disabled={Boolean(consumingItemId) || Boolean(removingItemId) || record.count <= 0}
+              onClick={() => void removeInventoryItem(record)}
+            >
+              Remove
+            </Button>
+          </Space>
         ),
       },
     ],
-    [consumeInventoryItem, consumingItemId],
+    [consumeInventoryItem, consumingItemId, removeInventoryItem, removingItemId],
   );
 
   return (

--- a/app/households/[id]/stats/page.tsx
+++ b/app/households/[id]/stats/page.tsx
@@ -13,7 +13,6 @@ import {
   Modal,
   Progress,
   Row,
-  Select,
   Space,
   Spin,
   Table,
@@ -139,14 +138,7 @@ export default function StatsPage() {
   const [savingBudget, setSavingBudget] = useState(false);
   const [budgetForm] = Form.useForm<{ dailyCalorieTarget: number }>();
 
-  const [consumeModalOpen, setConsumeModalOpen] = useState(false);
-  const [consuming, setConsuming] = useState(false);
-  const [consumeForm] = Form.useForm<{ itemId: number; quantity: number }>();
-  const selectedConsumeItemId = Form.useWatch("itemId", consumeForm);
-  const selectedConsumeItem = useMemo(
-    () => pantry?.items.find((i) => i.id === selectedConsumeItemId),
-    [pantry?.items, selectedConsumeItemId],
-  );
+  const [consumingItemId, setConsumingItemId] = useState<number | null>(null);
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
 
   const loadDashboard = useCallback(async () => {
@@ -266,46 +258,37 @@ export default function StatsPage() {
     }
   };
 
-  const openConsumeModal = () => {
-    if (!pantry?.items.length) {
-      message.info("Add items to your pantry before recording consumption.");
-      return;
-    }
-    const first = pantry.items[0];
-    consumeForm.setFieldsValue({ itemId: first.id, quantity: 1 });
-    setConsumeModalOpen(true);
-  };
+  const consumeInventoryItem = useCallback(
+    async (item: PantryItem) => {
+      if (!item.id) {
+        message.error("Selected item is missing an item ID.");
+        return;
+      }
+      if (!item.count || item.count <= 0) {
+        message.error("This item is no longer available in the pantry.");
+        return;
+      }
 
-  const submitConsumption = async () => {
-    const values = await consumeForm.validateFields();
-    const item = pantry?.items.find((i) => i.id === values.itemId);
-    if (!item) {
-      message.error("Selected item is no longer in the pantry.");
-      return;
-    }
-    if (values.quantity > item.count) {
-      message.error("Quantity cannot exceed available units.");
-      return;
-    }
-    setConsuming(true);
-    try {
-      const res = await api.post<ConsumePantryItemResponse>(
-        `/households/${householdId}/pantry/${values.itemId}/consume`,
-        { quantity: values.quantity },
-      );
-      message.success(
-        res.removed
-          ? "Item fully consumed and removed from pantry."
-          : "Consumption recorded.",
-      );
-      setConsumeModalOpen(false);
-      await loadDashboard();
-    } catch (error) {
-      message.error(error instanceof Error ? error.message : "Could not record consumption.");
-    } finally {
-      setConsuming(false);
-    }
-  };
+      setConsumingItemId(item.id);
+      try {
+        const res = await api.post<ConsumePantryItemResponse>(
+          `/households/${householdId}/pantry/${item.id}/consume`,
+          { quantity: 1 },
+        );
+        message.success(
+          res.removed
+            ? "Item fully consumed and removed from pantry."
+            : "Consumption recorded.",
+        );
+        await loadDashboard();
+      } catch (error) {
+        message.error(error instanceof Error ? error.message : "Could not record consumption.");
+      } finally {
+        setConsumingItemId(null);
+      }
+    },
+    [api, householdId, loadDashboard, message],
+  );
 
   const inventoryColumns: TableProps<PantryItem>["columns"] = useMemo(
     () => [
@@ -361,8 +344,25 @@ export default function StatsPage() {
             <Tag color="success">In stock</Tag>
           ),
       },
+      {
+        title: "Action",
+        key: "action",
+        width: 130,
+        render: (_: unknown, record: PantryItem) => (
+          <Button
+            type="primary"
+            size="small"
+            icon={<RestOutlined />}
+            loading={consumingItemId === record.id}
+            disabled={Boolean(consumingItemId) || record.count <= 0}
+            onClick={() => void consumeInventoryItem(record)}
+          >
+            Consume
+          </Button>
+        ),
+      },
     ],
-    [],
+    [consumeInventoryItem, consumingItemId],
   );
 
   return (
@@ -566,15 +566,6 @@ export default function StatsPage() {
               </Col>
               <Col xs={24} lg={9}>
                 <div className={statsStyles.rightStack}>
-                  <Button
-                    type="primary"
-                    className={statsStyles.recordConsumptionBtn}
-                    icon={<RestOutlined />}
-                    onClick={openConsumeModal}
-                  >
-                    Record consumption
-                  </Button>
-
                   <Card className={`${statsStyles.panelCard} ${statsStyles.activityCard}`} title="Recent activity" variant="borderless">
                     {activity.length === 0 ? (
                       <Text type="secondary" style={{ fontSize: 13 }}>
@@ -661,53 +652,6 @@ export default function StatsPage() {
         </Form>
       </Modal>
 
-      <Modal
-        title="Record consumption"
-        open={consumeModalOpen}
-        onCancel={() => setConsumeModalOpen(false)}
-        onOk={() => void submitConsumption()}
-        confirmLoading={consuming}
-        okText="Log consumption"
-      >
-        <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-          Select an item and how many units you used. Calories are calculated from each item&apos;s
-          kcal per package.
-        </Paragraph>
-        <Form form={consumeForm} layout="vertical">
-          <Form.Item
-            label="Pantry item"
-            name="itemId"
-            rules={[{ required: true, message: "Select an item" }]}
-          >
-            <Select
-              placeholder="Choose item"
-              options={pantry?.items.map((i) => ({
-                value: i.id,
-                label: `${i.name} (${i.count} available)`,
-              }))}
-              onChange={() => consumeForm.setFieldValue("quantity", 1)}
-            />
-          </Form.Item>
-          <Form.Item
-            label="Quantity consumed"
-            name="quantity"
-            rules={[
-              { required: true, message: "Enter quantity" },
-              {
-                type: "number",
-                min: 1,
-                message: "At least 1",
-              },
-            ]}
-          >
-            <InputNumber
-              min={1}
-              max={selectedConsumeItem?.count ?? undefined}
-              style={{ width: "100%" }}
-            />
-          </Form.Item>
-        </Form>
-      </Modal>
     </VirtualPantryAppShell>
   );
 }

--- a/app/open-food-facts/page.tsx
+++ b/app/open-food-facts/page.tsx
@@ -136,7 +136,7 @@ export default function OpenFoodFactsPortalPage() {
                     : router.push("/households")
                 }
               >
-                Back to household page
+                Back to pantry stats
               </Button>
               <Button
                 type="primary"

--- a/app/styles/stats.module.css
+++ b/app/styles/stats.module.css
@@ -211,3 +211,7 @@
   border: 1px solid #e2e8d4 !important;
   background: #ffffff !important;
 }
+
+.deltaPos {
+  color: #1b5e20;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2243,9 +2243,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2261,9 +2258,6 @@
       "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2281,9 +2275,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2299,9 +2290,6 @@
       "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
added a remove button in the entry that deletes 1 count of the PantryItem from the household. 

Added the scan product barcode button in household/[id]/stats alongside "add items from off portal"

Open food facts: changed the "back to household page" button into "back to pantry stats" that routes to household/ID/stats instead