### PR TITLE
households/[id] safe guard

### DIFF
--- a/app/households/[id]/members/page.tsx
+++ b/app/households/[id]/members/page.tsx
@@ -6,11 +6,25 @@ import { useApi } from "@/hooks/useApi";
 import useSessionStorage from "@/hooks/useSessionStorage";
 import type { HouseholdWithRole } from "@/types/household";
 import { VirtualPantryAppShell } from "@/components/VirtualPantryAppShell";
-import { Button, Col, Row, Tag, Typography } from "antd";
+import { App, Button, Col, Row, Tag, Typography } from "antd";
 import styles from "@/styles/households.module.css";
 import { useAuthGuard } from "@/hooks/useAuthGuard";
 
 const { Title, Paragraph } = Typography;
+
+type HouseholdLookup = {
+  householdId: number;
+  name: string;
+};
+
+function routeBackToSafeHouseholdsPage(router: ReturnType<typeof useRouter>) {
+  if (globalThis.window?.history.length > 1) {
+    router.back();
+    return;
+  }
+
+  router.replace("/households");
+}
 
 interface HouseholdMember {
   userId: number;
@@ -30,6 +44,7 @@ export default function HouseholdMembersPage() {
   const params = useParams<{ id: string }>();
   const searchParams = useSearchParams();
   const api = useApi();
+  const { message } = App.useApp();
 
   const { value: cachedHouseholds } = useSessionStorage<HouseholdWithRole[]>("households", []);
   const householdId = Number(params.id);
@@ -43,9 +58,56 @@ export default function HouseholdMembersPage() {
   const [members, setMembers] = useState<HouseholdMember[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [hasValidHouseholdRoute, setHasValidHouseholdRoute] = useState(false);
 
   useEffect(() => {
-    if (!isAuthenticated) return;
+    let cancelled = false;
+
+    const rejectInvalidHouseholdRoute = (text: string) => {
+      if (cancelled) return;
+      setHasValidHouseholdRoute(false);
+      setIsLoading(false);
+      message.error(text);
+      routeBackToSafeHouseholdsPage(router);
+    };
+
+    const validateHouseholdRoute = async () => {
+      setHasValidHouseholdRoute(false);
+
+      if (!Number.isInteger(householdId) || householdId <= 0) {
+        rejectInvalidHouseholdRoute("Household ID is invalid.");
+        return;
+      }
+
+      try {
+        const household = await api.get<HouseholdLookup>(`/households/${householdId}`);
+        if (cancelled) return;
+
+        const requestedName = searchParams.get("name")?.trim();
+        if (requestedName && requestedName !== household.name) {
+          rejectInvalidHouseholdRoute("Household name does not exist for this household.");
+          return;
+        }
+
+        setHasValidHouseholdRoute(true);
+      } catch (error) {
+        rejectInvalidHouseholdRoute(
+          error instanceof Error && error.message.includes("User is not a member")
+            ? "You are not a member of this household."
+            : "Household ID does not exist.",
+        );
+      }
+    };
+
+    void validateHouseholdRoute();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, householdId, message, router, searchParams]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !hasValidHouseholdRoute) return;
     if (!Number.isFinite(householdId) || householdId <= 0) {
       setErrorMessage("Invalid household ID.");
       setIsLoading(false);
@@ -66,7 +128,11 @@ export default function HouseholdMembersPage() {
     };
     void fetchMembers();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [householdId, isAuthenticated]);
+  }, [householdId, isAuthenticated, hasValidHouseholdRoute]);
+
+  if (!hasValidHouseholdRoute) {
+    return null;
+  }
 
   return (
     <VirtualPantryAppShell activeNav="households">

--- a/app/households/[id]/page.tsx
+++ b/app/households/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import useSessionStorage from "@/hooks/useSessionStorage";
 import { usePantryWebSocket } from "@/hooks/usePantryWebSocket";
@@ -15,6 +15,7 @@ import {
   Table,
   Typography,
   Alert,
+  App,
   Row,
   Col,
   Tag,
@@ -33,6 +34,21 @@ import { useAuthGuard } from "@/hooks/useAuthGuard";
 
 const { Title, Paragraph, Text } = Typography;
 
+type HouseholdLookup = {
+  householdId: number;
+  name: string;
+};
+
+function routeBackToSafeHouseholdsPage(router: ReturnType<typeof useRouter>) {
+  if (globalThis.window?.history.length > 1) {
+    router.back();
+    return;
+  }
+
+  router.replace("/households");
+}
+
+
 function formatDate(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -50,7 +66,9 @@ export default function HouseholdPantryPage() {
   const { isAuthenticated } = useAuthGuard();
   const router = useRouter();
   const params = useParams<{ id: string }>();
+  const searchParams = useSearchParams();
   const api = useApi();
+  const { message } = App.useApp();
 
   const { value: username } = useSessionStorage<string>("username", "");
   const { value: token } = useSessionStorage<string>("token", "");
@@ -64,21 +82,65 @@ export default function HouseholdPantryPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [hasValidHouseholdRoute, setHasValidHouseholdRoute] = useState(false);
 
   const householdName = useMemo(() => {
-    if (typeof globalThis.window !== "undefined") {
-      const queryParams = new URLSearchParams(globalThis.location.search);
-      const queryName = queryParams.get("name");
-      if (queryName?.trim()) {
-        return queryName.trim();
-      }
+    const queryName = searchParams.get("name");
+    if (queryName?.trim()) {
+      return queryName.trim();
     }
 
     return (
       cachedHouseholds.find((household) => household.householdId === householdId)
         ?.name ?? `Household ${householdId}`
     );
-  }, [cachedHouseholds, householdId]);
+  }, [cachedHouseholds, householdId, searchParams]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const rejectInvalidHouseholdRoute = (text: string) => {
+      if (cancelled) return;
+      setHasValidHouseholdRoute(false);
+      setIsLoading(false);
+      message.error(text);
+      routeBackToSafeHouseholdsPage(router);
+    };
+
+    const validateHouseholdRoute = async () => {
+      setHasValidHouseholdRoute(false);
+
+      if (!Number.isInteger(householdId) || householdId <= 0) {
+        rejectInvalidHouseholdRoute("Household ID is invalid.");
+        return;
+      }
+
+      try {
+        const household = await api.get<HouseholdLookup>(`/households/${householdId}`);
+        if (cancelled) return;
+
+        const requestedName = searchParams.get("name")?.trim();
+        if (requestedName && requestedName !== household.name) {
+          rejectInvalidHouseholdRoute("Household name does not exist for this household.");
+          return;
+        }
+
+        setHasValidHouseholdRoute(true);
+      } catch (error) {
+        rejectInvalidHouseholdRoute(
+          error instanceof Error && error.message.includes("User is not a member")
+            ? "You are not a member of this household."
+            : "Household ID does not exist.",
+        );
+      }
+    };
+
+    void validateHouseholdRoute();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, householdId, message, router, searchParams]);
 
   const fetchPantry = useCallback(async () => {
     if (!Number.isFinite(householdId) || householdId <= 0) {
@@ -109,12 +171,12 @@ export default function HouseholdPantryPage() {
   }, [api, householdId]);
 
   useEffect(() => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || !hasValidHouseholdRoute) return;
     void fetchPantry();
-  }, [fetchPantry, isAuthenticated]);
+  }, [fetchPantry, hasValidHouseholdRoute, isAuthenticated]);
 
   const { connected: wsConnected, hasConnectedOnce } = usePantryWebSocket({
-    householdId: Number.isFinite(householdId) && householdId > 0 ? householdId : null,
+    householdId: hasValidHouseholdRoute && Number.isFinite(householdId) && householdId > 0 ? householdId : null,
     token,
     onMessage: () => {
       void fetchPantry();
@@ -174,6 +236,10 @@ export default function HouseholdPantryPage() {
       render: (value: string) => formatDate(value),
     },
   ];
+
+  if (!hasValidHouseholdRoute) {
+    return null;
+  }
 
   return (
     <div

--- a/app/households/[id]/stats/page.tsx
+++ b/app/households/[id]/stats/page.tsx
@@ -29,7 +29,7 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import dayjs, { Dayjs } from "dayjs";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import useSessionStorage from "@/hooks/useSessionStorage";
 import { usePantryWebSocket } from "@/hooks/usePantryWebSocket";
@@ -48,6 +48,20 @@ const { Title, Paragraph, Text } = Typography;
 const FOREST = "#1b5e20";
 const DANGER = "#c62828";
 const MUTED = "#5d6a5d";
+
+type HouseholdLookup = {
+  householdId: number;
+  name: string;
+};
+
+function routeBackToSafeHouseholdsPage(router: ReturnType<typeof useRouter>) {
+  if (globalThis.window?.history.length > 1) {
+    router.back();
+    return;
+  }
+
+  router.replace("/households");
+}
 
 type ActivityEntry = {
   id: string;
@@ -130,6 +144,7 @@ export default function StatsPage() {
   const api = useApi();
   const router = useRouter();
   const params = useParams<{ id: string }>();
+  const searchParams = useSearchParams();
   const { message } = App.useApp();
 
   const householdId = Number(params.id);
@@ -163,9 +178,10 @@ export default function StatsPage() {
   const [consumingItemId, setConsumingItemId] = useState<number | null>(null);
   const [removingItemId, setRemovingItemId] = useState<number | null>(null);
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
+  const [hasValidHouseholdRoute, setHasValidHouseholdRoute] = useState(false);
 
   const loadDashboard = useCallback(async () => {
-    if (!householdId || !startDate) {
+    if (!hasValidHouseholdRoute || !householdId || !startDate) {
       return;
     }
 
@@ -206,10 +222,55 @@ export default function StatsPage() {
     } finally {
       setLoading(false);
     }
-  }, [api, message, householdId, startDate]);
+  }, [api, message, householdId, startDate, hasValidHouseholdRoute]);
 
   useEffect(() => {
-    if (!householdId || !cachedHouseholds.length) return;
+    let cancelled = false;
+
+    const rejectInvalidHouseholdRoute = (text: string) => {
+      if (cancelled) return;
+      setHasValidHouseholdRoute(false);
+      message.error(text);
+      routeBackToSafeHouseholdsPage(router);
+    };
+
+    const validateHouseholdRoute = async () => {
+      setHasValidHouseholdRoute(false);
+
+      if (!Number.isInteger(householdId) || householdId <= 0) {
+        rejectInvalidHouseholdRoute("Household ID is invalid.");
+        return;
+      }
+
+      try {
+        const household = await api.get<HouseholdLookup>(`/households/${householdId}`);
+        if (cancelled) return;
+
+        const requestedName = searchParams.get("name")?.trim();
+        if (requestedName && requestedName !== household.name) {
+          rejectInvalidHouseholdRoute("Household name does not exist for this household.");
+          return;
+        }
+
+        setHasValidHouseholdRoute(true);
+      } catch (error) {
+        rejectInvalidHouseholdRoute(
+          error instanceof Error && error.message.includes("User is not a member")
+            ? "You are not a member of this household."
+            : "Household ID does not exist.",
+        );
+      }
+    };
+
+    void validateHouseholdRoute();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, householdId, message, router, searchParams]);
+
+  useEffect(() => {
+    if (!hasValidHouseholdRoute || !householdId || !cachedHouseholds.length) return;
     if (initializedForHousehold.current === householdId) return;
     initializedForHousehold.current = householdId;
 
@@ -221,16 +282,16 @@ export default function StatsPage() {
     } else {
       setStartDate(sevenDaysAgo);
     }
-  }, [householdId, cachedHouseholds]);
+  }, [householdId, cachedHouseholds, hasValidHouseholdRoute]);
 
   useEffect(() => {
-    if (isAuthenticated && householdId && startDate) {
+    if (isAuthenticated && hasValidHouseholdRoute && householdId && startDate) {
       void loadDashboard();
     }
-  }, [isAuthenticated, loadDashboard, householdId, startDate]);
+  }, [isAuthenticated, loadDashboard, householdId, startDate, hasValidHouseholdRoute]);
 
   usePantryWebSocket({
-    householdId: Number.isFinite(householdId) && householdId > 0 ? householdId : null,
+    householdId: hasValidHouseholdRoute && Number.isFinite(householdId) && householdId > 0 ? householdId : null,
     token,
     onMessage: () => {
       void loadDashboard();
@@ -431,6 +492,10 @@ export default function StatsPage() {
     ],
     [consumeInventoryItem, consumingItemId, removeInventoryItem, removingItemId],
   );
+
+  if (!hasValidHouseholdRoute) {
+    return null;
+  }
 
   return (
     <VirtualPantryAppShell activeNav="pantry">


### PR DESCRIPTION
Prevent routing to household ID that doesn't exist, and a proper error message will be displayed if attempted.