### PR TITLE
Enrich dashboard: member-aware activity, weekly calories, contextual tip

### DIFF
--- a/app/styles/dashboard.module.css
+++ b/app/styles/dashboard.module.css
@@ -1,0 +1,389 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.title {
+  margin: 0 !important;
+  color: #1b2a1b !important;
+}
+
+.subtitle {
+  margin: 4px 0 8px !important;
+  color: #687467 !important;
+}
+
+.headerMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  color: #4d5a4c;
+  font-size: 13px;
+}
+
+.headerMetaItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #4d5a4c;
+}
+
+.householdName {
+  color: #263726;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 1.25fr);
+  gap: 20px;
+}
+
+.leftColumn,
+.rightColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.alertCard {
+  border-radius: 14px !important;
+  border: 1px solid #f1cfcf !important;
+  background: #fce7e7 !important;
+}
+
+.alertLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  color: #7b1d22;
+}
+
+.alertTopRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.alertIcon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(173, 40, 48, 0.15);
+  color: #ad2830;
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.alertContent {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  color: #7b1d22;
+  margin-top: 10px;
+}
+
+.alertValue {
+  font-size: 48px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.alertUnit {
+  font-size: 26px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.alertFootnote {
+  margin-top: 6px;
+  color: #9a2c32;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.kpiRow {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.kpiCard,
+.kpiCardGreen,
+.kpiCardOutline {
+  border-radius: 14px !important;
+  min-height: 150px;
+}
+
+.kpiCard {
+  border: 1px solid #e5ebda !important;
+  background: #f5f7f1 !important;
+}
+
+.kpiCardOutline {
+  border: 1px solid #e7e4d8 !important;
+  background: #fbf8ef !important;
+}
+
+.kpiCardGreen {
+  border: 1px solid #d8ebd3 !important;
+  background: #dff3d8 !important;
+}
+
+.kpiLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  color: #415341;
+}
+
+.kpiValue {
+  margin-top: 10px;
+  font-size: 44px;
+  line-height: 1;
+  font-weight: 700;
+  color: #172517;
+}
+
+.kpiTitle {
+  margin-top: 10px;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.15;
+  color: #1c3d1f;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+
+.kpiSub {
+  margin-top: 6px;
+  color: #4e644f;
+  font-size: 13px;
+}
+
+.sectionTitleRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.inventoryCard {
+  border-radius: 14px !important;
+}
+
+.inventoryTable {
+  display: flex;
+  flex-direction: column;
+}
+
+.inventoryHead,
+.inventoryRow {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 12px;
+  align-items: center;
+}
+
+.inventoryHead {
+  padding: 10px 0;
+  border-bottom: 1px solid #edf2e7;
+  color: #667465;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.inventoryRow {
+  padding: 12px 0;
+  border-bottom: 1px solid #f1f5ec;
+  color: #243224;
+}
+
+.productCell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.categoryPill {
+  justify-self: start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #e2f0dd;
+  color: #2f6d31;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.statusDanger {
+  color: #ad2830;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.statusOk {
+  color: #2e7d32;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.activityCard,
+.tipCard,
+.emptyCard {
+  border-radius: 14px !important;
+}
+
+.activityList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.activityItem {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.activityAvatar {
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  color: #132713;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.activityBody {
+  min-width: 0;
+  flex: 1;
+}
+
+.activityText {
+  color: #1a2a1a;
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.activityActor {
+  color: #0f2a10;
+  font-weight: 700;
+}
+
+.activityVerb {
+  color: #5e6d5e;
+}
+
+.activityAmount {
+  color: #0f2a10;
+  font-weight: 700;
+}
+
+.activityProduct {
+  color: #1a2a1a;
+  font-weight: 600;
+}
+
+.activityRemoved {
+  color: #8a7b5a;
+  font-style: italic;
+}
+
+.activityTime {
+  color: #7f8d7f;
+  font-size: 12px;
+  margin-top: 3px;
+}
+
+.avatarTone1 {
+  background: linear-gradient(140deg, #f2d7c5, #efb3ae);
+}
+
+.avatarTone2 {
+  background: linear-gradient(140deg, #d7e4f4, #b8c8e6);
+}
+
+.avatarTone3 {
+  background: linear-gradient(140deg, #f5e9bf, #efd598);
+}
+
+.avatarTone4 {
+  background: linear-gradient(140deg, #d2ead4, #a8d4ab);
+}
+
+.avatarToneMuted {
+  background: #e2e2e0;
+  color: #6b6b66;
+}
+
+.tipCard {
+  background: #111 !important;
+  color: #f8f8f8 !important;
+}
+
+.tipLabel {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: #c8cec8;
+  margin-bottom: 8px;
+}
+
+.tipText {
+  font-size: 19px;
+  line-height: 1.3;
+  font-weight: 600;
+  color: #f8f8f8;
+}
+
+@media (max-width: 1200px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kpiRow {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .kpiRow {
+    grid-template-columns: 1fr;
+  }
+
+  .inventoryHead,
+  .inventoryRow {
+    grid-template-columns: 1.5fr 1fr 1fr 1fr;
+  }
+
+  .tipText {
+    font-size: 17px;
+  }
+}

--- a/app/types/consumption.ts
+++ b/app/types/consumption.ts
@@ -7,4 +7,6 @@ export interface ConsumptionLogEntry {
   consumedQuantity: number;
   consumedCalories: number;
   userId: number;
+  /** Added in the `feature/consumption-log-include-username` server change. Optional for backwards-compat. */
+  username?: string;
 }

--- a/app/users/page.test.tsx
+++ b/app/users/page.test.tsx
@@ -4,15 +4,17 @@ import UsersPage from "@/users/page";
 
 const pushMock = jest.fn();
 const getMock = jest.fn();
-const postMock = jest.fn();
-const clearTokenMock = jest.fn();
-const apiMock = { get: getMock, post: postMock };
+const errorMock = jest.fn();
+const apiMock = { get: getMock };
+
+let mockHouseholds: any[] = [];
+let mockSelectedHouseholdId: number | null = null;
 
 jest.mock("antd", () => {
-  const Card = ({ children, title, loading }: any) => (
+  const Card = ({ children, title }: any) => (
     <div>
-      <div>{title}</div>
-      <div>{loading ? "loading" : children}</div>
+      {title ? <div>{title}</div> : null}
+      <div>{children}</div>
     </div>
   );
 
@@ -22,28 +24,26 @@ jest.mock("antd", () => {
     </button>
   );
 
-  const Space = ({ children }: any) => <div>{children}</div>;
+  const Spin = () => <div>loading</div>;
+  const Typography = {
+    Title: ({ children }: any) => <h1>{children}</h1>,
+    Paragraph: ({ children }: any) => <p>{children}</p>,
+    Text: ({ children }: any) => <span>{children}</span>,
+  };
+  const Tag = ({ children }: any) => <span>{children}</span>;
+  const App = {
+    useApp: () => ({ message: { error: errorMock } }),
+  };
 
-  const Table = ({ dataSource, onRow }: any) => (
-    <div>
-      {dataSource.map((row: any) => {
-        const rowProps = onRow ? onRow(row) : {};
-        return (
-          <div
-            key={row.id}
-            data-testid={`user-row-${row.id}`}
-            onClick={rowProps.onClick}
-            style={rowProps.style}
-          >
-            {row.username}
-          </div>
-        );
-      })}
-    </div>
-  );
-
-  return { Button, Card, Space, Table };
+  return { App, Button, Card, Spin, Tag, Typography };
 });
+
+jest.mock("@ant-design/icons", () => ({
+  AppstoreOutlined: () => <span />,
+  HistoryOutlined: () => <span />,
+  PlusOutlined: () => <span />,
+  TeamOutlined: () => <span />,
+}));
 
 jest.mock("@/hooks/useAuthGuard", () => ({
   useAuthGuard: () => ({ isAuthenticated: true }),
@@ -57,60 +57,159 @@ jest.mock("@/hooks/useApi", () => ({
   useApi: () => apiMock,
 }));
 
+jest.mock("@/components/VirtualPantryAppShell", () => ({
+  VirtualPantryAppShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="shell">{children}</div>
+  ),
+}));
+
 jest.mock("@/hooks/useSessionStorage", () => ({
   __esModule: true,
-  default: () => ({ value: "stored-token", clear: clearTokenMock }),
+  default: (key: string) => {
+    if (key === "households") {
+      return { value: mockHouseholds, set: jest.fn(), clear: jest.fn() };
+    }
+    if (key === "selectedHouseholdId") {
+      return {
+        value: mockSelectedHouseholdId,
+        set: jest.fn(),
+        clear: jest.fn(),
+      };
+    }
+    return { value: "", set: jest.fn(), clear: jest.fn() };
+  },
 }));
+
+type ApiFixtures = {
+  pantry?: any;
+  logs?: any;
+  members?: any;
+  pantryError?: Error;
+};
+
+function routeApi(fixtures: ApiFixtures) {
+  getMock.mockImplementation((url: string) => {
+    if (url.startsWith("/households/10/pantry")) {
+      if (fixtures.pantryError) return Promise.reject(fixtures.pantryError);
+      return Promise.resolve(fixtures.pantry ?? { items: [], totalCalories: 0 });
+    }
+    if (url.startsWith("/households/10/consumption-logs")) {
+      return Promise.resolve(fixtures.logs ?? []);
+    }
+    if (url.startsWith("/households/10/members")) {
+      return Promise.resolve(fixtures.members ?? []);
+    }
+    return Promise.resolve(undefined);
+  });
+}
 
 describe("Users page", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    globalThis.alert = jest.fn();
+    mockHouseholds = [
+      { householdId: 10, name: "Team Kitchen", role: "owner" },
+    ];
+    mockSelectedHouseholdId = 10;
   });
 
-  it("fetches users on mount and navigates when a row is clicked", async () => {
-    getMock.mockResolvedValueOnce([
-      { id: 1, username: "tingting", name: "Ting Ting" },
-      { id: 2, username: "yifu", name: "Yifu" },
-    ]);
-
-    render(<UsersPage />);
-
-    await waitFor(() => {
-      expect(getMock).toHaveBeenCalledWith("/users");
+  it("loads dashboard data and renders user, product and weekly stats", async () => {
+    routeApi({
+      pantry: {
+        items: [
+          { id: 1, name: "Oat Milk", count: 2 },
+          { id: 2, name: "Bread", count: 8 },
+        ],
+        totalCalories: 240,
+      },
+      logs: [
+        {
+          logId: 1,
+          consumedAt: new Date().toISOString(),
+          productName: "Oat Milk",
+          consumedQuantity: 2,
+          consumedCalories: 200,
+          pantryItemId: 1,
+          userId: 5,
+        },
+      ],
+      members: [
+        { userId: 5, username: "tiffany", role: "owner", joinedAt: "2026-01-01T00:00:00Z" },
+      ],
     });
-    const secondUserRow = await screen.findByTestId("user-row-2");
-
-    fireEvent.click(secondUserRow);
-    expect(pushMock).toHaveBeenCalledWith("/users/2");
-  });
-
-
-  it("logs out through the API, clears the token, and redirects to login", async () => {
-    getMock.mockResolvedValueOnce([{ id: 1, username: "tingting", name: "Ting Ting" }]);
-    postMock.mockResolvedValueOnce({});
-
-    render(<UsersPage />);
-
-    await screen.findByTestId("user-row-1");
-    fireEvent.click(screen.getByRole("button", { name: "Logout" }));
-
-    await waitFor(() => {
-      expect(postMock).toHaveBeenCalledWith("/users/logout", { token: "stored-token" });
-      expect(clearTokenMock).toHaveBeenCalled();
-      expect(pushMock).toHaveBeenCalledWith("/login");
-    });
-  });
-
-  it("alerts when fetching users fails", async () => {
-    getMock.mockRejectedValueOnce(new Error("boom"));
 
     render(<UsersPage />);
 
     await waitFor(() => {
-      expect(globalThis.alert).toHaveBeenCalledWith(
-        "Something went wrong while fetching users:\nboom",
+      expect(getMock).toHaveBeenCalledWith("/households/10/pantry");
+      expect(getMock).toHaveBeenCalledWith(
+        expect.stringContaining("/households/10/consumption-logs?limit="),
       );
+      expect(getMock).toHaveBeenCalledWith("/households/10/members");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Pantry Overview")).toBeInTheDocument();
+      expect(screen.getByText("Team Kitchen")).toBeInTheDocument();
+      expect(screen.getByText("Most consumed")).toBeInTheDocument();
+      expect(screen.getByText("Calories this week")).toBeInTheDocument();
+      expect(screen.getByText("tiffany")).toBeInTheDocument();
+      expect(screen.getAllByText("Oat Milk").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("skips removed items when computing most consumed", async () => {
+    routeApi({
+      pantry: { items: [{ id: 1, name: "Bread", count: 5 }], totalCalories: 0 },
+      logs: [
+        {
+          logId: 1,
+          consumedAt: new Date().toISOString(),
+          productName: "Removed item",
+          consumedQuantity: 3,
+          consumedCalories: 150,
+          pantryItemId: 99,
+          userId: 5,
+        },
+      ],
+      members: [],
+    });
+
+    render(<UsersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No data yet")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates to add product with household context", async () => {
+    routeApi({});
+    render(<UsersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Add Product/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Add Product/i }));
+    expect(pushMock).toHaveBeenCalledWith(
+      expect.stringContaining("/open-food-facts?householdId=10"),
+    );
+  });
+
+  it("shows fallback state when no households exist", async () => {
+    mockHouseholds = [];
+
+    render(<UsersPage />);
+    expect(screen.getByText("No household selected")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Go to Households/i }));
+    expect(pushMock).toHaveBeenCalledWith("/households");
+  });
+
+  it("shows message when dashboard request fails", async () => {
+    routeApi({ pantryError: new Error("boom") });
+
+    render(<UsersPage />);
+
+    await waitFor(() => {
+      expect(errorMock).toHaveBeenCalled();
     });
   });
 });

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,128 +1,426 @@
-// this code is part of S2 to display a list of all registered users
-// clicking on a user in this list will display /app/users/[id]/page.tsx
-"use client"; // For components that need React hooks and browser APIs, SSR (server side rendering) has to be disabled. Read more here: https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering
+"use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
+import { VirtualPantryAppShell } from "@/components/VirtualPantryAppShell";
 import useSessionStorage from "@/hooks/useSessionStorage";
 import { useAuthGuard } from "@/hooks/useAuthGuard";
-import { User } from "@/types/user";
-import { Button, Card, Space, Table } from "antd";
-import type { TableProps } from "antd"; // antd component library allows imports of types
-// Optionally, you can import a CSS module or file for additional styling:
-// import "@/styles/views/Dashboard.scss";
+import type { PantryOverview } from "@/types/pantry";
+import type { HouseholdWithRole } from "@/types/household";
+import type { ConsumptionLogEntry } from "@/types/consumption";
+import { App, Button, Card, Spin, Tag, Typography } from "antd";
+import {
+  AppstoreOutlined,
+  HistoryOutlined,
+  PlusOutlined,
+  TeamOutlined,
+} from "@ant-design/icons";
+import dayjs from "dayjs";
+import dashboardStyles from "@/styles/dashboard.module.css";
 
-// Columns for the antd table of User objects
-const columns: TableProps<User>["columns"] = [
-  {
-    title: "Username",
-    dataIndex: "username",
-    key: "username",
-  },
-  {
-    title: "Name",
-    dataIndex: "name",
-    key: "name",
-  },
-  {
-    title: "Id",
-    dataIndex: "id",
-    key: "id",
-  },
-];
+const { Title, Paragraph, Text } = Typography;
 
-const Dashboard: React.FC = () => {
+const REMOVED_ITEM_LABEL = "Removed item";
+const ACTIVITY_HISTORY_LIMIT = 30;
+
+interface HouseholdMember {
+  userId: number;
+  username: string;
+  role: "owner" | "member";
+  joinedAt: string;
+}
+
+type InventoryRow = {
+  id: number;
+  product: string;
+  quantity: string;
+  category: string;
+  status: string;
+  statusTone: "danger" | "ok";
+};
+
+function inferCategory(name: string): string {
+  const n = name.trim();
+  if (/milk|cheese|yogurt|cream|butter|dairy/i.test(n)) return "Dairy";
+  if (/fruit|berry|vegetable|lettuce|tomato|produce|apple|orange/i.test(n)) return "Produce";
+  if (/bread|bun|bagel|bakery|toast|croissant/i.test(n)) return "Bakery";
+  return "Pantry";
+}
+
+function formatAgo(iso: string): string {
+  const mins = Math.max(0, dayjs().diff(dayjs(iso), "minute"));
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins} min ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days > 1 ? "s" : ""} ago`;
+}
+
+function initialsOf(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "?";
+  const parts = trimmed.split(/\s+/).slice(0, 2);
+  return parts.map((p) => p[0]?.toUpperCase() ?? "").join("") || "?";
+}
+
+const DashboardPage: React.FC = () => {
   const { isAuthenticated } = useAuthGuard();
   const router = useRouter();
-  const apiService = useApi();
-  const [users, setUsers] = useState<User[] | null>(null);
-  // useLocalStorage hook example use
-  // The hook returns an object with the value and two functions
-  // Simply choose what you need from the hook:
+  const api = useApi();
+  const { message } = App.useApp();
+  const { value: households } = useSessionStorage<HouseholdWithRole[]>("households", []);
   const {
-    value: token,
-    // set: setToken, // is commented out because we dont need to set or update the token value
-    clear: clearToken, // all we need in this scenario is a method to clear the token
-  } = useSessionStorage<string>("token", ""); // session auth is intentionally scoped to the current browser session.
-  const { clear: clearUsername } = useSessionStorage<string>("username", "");
+    value: selectedHouseholdId,
+    set: setSelectedHouseholdId,
+  } = useSessionStorage<number | null>("selectedHouseholdId", null);
 
-  const handleLogout = async (): Promise<void> => {
-    try {
-      await apiService.post("/users/logout", {
-        token,
-      });
+  const [loading, setLoading] = useState(false);
+  const [pantry, setPantry] = useState<PantryOverview | null>(null);
+  const [activity, setActivity] = useState<ConsumptionLogEntry[]>([]);
+  const [members, setMembers] = useState<HouseholdMember[]>([]);
 
-      // Clear local auth state only after backend confirms logout.
-      clearToken();
-      clearUsername();
-      router.push("/login");
-    } catch (error) {
-      if (error instanceof Error) {
-        alert(`Logout request failed:\n${error.message}`);
-      } else {
-        alert("Logout request failed due to an unknown error.");
-      }
+  const activeHousehold = useMemo(() => {
+    if (!households.length) return null;
+    if (selectedHouseholdId !== null) {
+      const matched = households.find((h) => h.householdId === selectedHouseholdId);
+      if (matched) return matched;
     }
-  };
+    return households[0];
+  }, [households, selectedHouseholdId]);
 
   useEffect(() => {
-    if (!isAuthenticated) return;
+    if (!activeHousehold) return;
+    if (selectedHouseholdId === activeHousehold.householdId) return;
+    setSelectedHouseholdId(activeHousehold.householdId);
+  }, [activeHousehold, selectedHouseholdId, setSelectedHouseholdId]);
 
-    const fetchUsers = async () => {
+  useEffect(() => {
+    if (!isAuthenticated || !activeHousehold) return;
+
+    const loadDashboard = async () => {
+      setLoading(true);
       try {
-        // apiService.get<User[]> returns the parsed JSON object directly,
-        // thus we can simply assign it to our users variable.
-        const users: User[] = await apiService.get<User[]>("/users");
-        setUsers(users);
-        console.log("Fetched users:", users);
+        const [pantryRes, logsRes, membersRes] = await Promise.all([
+          api.get<PantryOverview>(`/households/${activeHousehold.householdId}/pantry`),
+          api.get<ConsumptionLogEntry[]>(
+            `/households/${activeHousehold.householdId}/consumption-logs?limit=${ACTIVITY_HISTORY_LIMIT}`,
+          ),
+          api
+            .get<HouseholdMember[]>(`/households/${activeHousehold.householdId}/members`)
+            .catch(() => [] as HouseholdMember[]),
+        ]);
+        setPantry(pantryRes && Array.isArray(pantryRes.items) ? pantryRes : { items: [], totalCalories: 0 });
+        setActivity(Array.isArray(logsRes) ? logsRes : []);
+        setMembers(Array.isArray(membersRes) ? membersRes : []);
       } catch (error) {
-        if (error instanceof Error) {
-          alert(`Something went wrong while fetching users:\n${error.message}`);
-        } else {
-          console.error("An unknown error occurred while fetching users.");
-        }
+        message.error(error instanceof Error ? error.message : "Could not load dashboard data.");
+      } finally {
+        setLoading(false);
       }
     };
 
-    fetchUsers();
-  }, [apiService, isAuthenticated]); // dependency apiService does not re-trigger the useEffect on every render because the hook uses memoization (check useApi.tsx in the hooks).
-  // if the dependency array is left empty, the useEffect will trigger exactly once
-  // if the dependency array is left away, the useEffect will run on every state change. Since we do a state change to users in the useEffect, this results in an infinite loop.
-  // read more here: https://react.dev/reference/react/useEffect#specifying-reactive-dependencies
+    void loadDashboard();
+  }, [activeHousehold, api, isAuthenticated, message]);
+
+  const memberNameById = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const m of members) {
+      map.set(m.userId, m.username);
+    }
+    return map;
+  }, [members]);
+
+  const lowStockCount = useMemo(() => {
+    return (pantry?.items ?? []).filter((item) => item.count <= 2).length;
+  }, [pantry?.items]);
+
+  const totalUnits = useMemo(() => {
+    return (pantry?.items ?? []).reduce((sum, item) => sum + item.count, 0);
+  }, [pantry?.items]);
+
+  const oneWeekAgo = useMemo(() => dayjs().subtract(7, "day"), []);
+
+  const weeklyLogs = useMemo(() => {
+    return activity.filter((log) => !dayjs(log.consumedAt).isBefore(oneWeekAgo));
+  }, [activity, oneWeekAgo]);
+
+  const mostConsumed = useMemo(() => {
+    if (!weeklyLogs.length) return null;
+    const totals = new Map<string, number>();
+    for (const log of weeklyLogs) {
+      if (!log.productName || log.productName === REMOVED_ITEM_LABEL) continue;
+      totals.set(log.productName, (totals.get(log.productName) ?? 0) + log.consumedQuantity);
+    }
+    let topName: string | null = null;
+    let topQty = 0;
+    for (const [name, qty] of totals.entries()) {
+      if (qty > topQty) {
+        topName = name;
+        topQty = qty;
+      }
+    }
+    return topName ? { name: topName, qty: topQty } : null;
+  }, [weeklyLogs]);
+
+  const weeklyCalories = useMemo(() => {
+    return weeklyLogs.reduce((sum, log) => sum + (log.consumedCalories ?? 0), 0);
+  }, [weeklyLogs]);
+
+  const inventoryRows = useMemo<InventoryRow[]>(() => {
+    return (pantry?.items ?? [])
+      .slice()
+      .sort((a, b) => a.count - b.count)
+      .slice(0, 6)
+      .map((item) => ({
+        id: item.id,
+        product: item.name,
+        quantity: `${item.count} unit${item.count > 1 ? "s" : ""}`,
+        category: inferCategory(item.name),
+        status: item.count <= 2 ? "LOW STOCK" : "FRESH",
+        statusTone: item.count <= 2 ? "danger" : "ok",
+      }));
+  }, [pantry?.items]);
+
+  const contextualTip = useMemo(() => {
+    if (lowStockCount > 0) {
+      return {
+        label: "Restock reminder",
+        text: `${lowStockCount} item${lowStockCount > 1 ? "s are" : " is"} running low (≤2 units). Consider refilling before your next cook.`,
+      };
+    }
+    if (!pantry?.items?.length) {
+      return {
+        label: "Get started",
+        text: "Your pantry is empty. Add your first product to start tracking what you eat.",
+      };
+    }
+    if (!activity.length) {
+      return {
+        label: "Log consumption",
+        text: "Record what you consume to unlock weekly stats, trends and smart suggestions.",
+      };
+    }
+    return {
+      label: "Kitchen tip",
+      text: "Keep herbs fresh for weeks by storing them upright in water, inside the fridge.",
+    };
+  }, [lowStockCount, pantry?.items, activity.length]);
+
+  if (!activeHousehold) {
+    return (
+      <VirtualPantryAppShell activeNav="dashboard">
+        <Card className={dashboardStyles.emptyCard}>
+          <Title level={3}>No household selected</Title>
+          <Paragraph type="secondary">
+            Create or join a household to unlock dashboard insights.
+          </Paragraph>
+          <Button type="primary" onClick={() => router.push("/households")}>
+            Go to Households
+          </Button>
+        </Card>
+      </VirtualPantryAppShell>
+    );
+  }
 
   return (
-    <div className="card-container">
-      <Card
-        title="Get all users from secure endpoint:"
-        loading={!users}
-        className="dashboard-container"
-      >
-        {users && (
-          <>
-            {/* antd Table: pass the columns and data, plus a rowKey for stable row identity */}
-            <Table<User>
-              columns={columns}
-              dataSource={users}
-              rowKey="id"
-              onRow={(row) => ({
-                onClick: () => router.push(`/users/${row.id}`),
-                style: { cursor: "pointer" },
-              })}
-            />
-            <Space>
-              <Button onClick={() => router.push("/households")}>
-                Households
-              </Button>
-              <Button onClick={() => void handleLogout()} type="primary">
-                Logout
-              </Button>
-            </Space>
-          </>
-        )}
-      </Card>
-    </div>
+    <VirtualPantryAppShell activeNav="dashboard">
+      <div className={dashboardStyles.header}>
+        <div>
+          <Title level={2} className={dashboardStyles.title}>Pantry Overview</Title>
+          <Paragraph className={dashboardStyles.subtitle}>
+            Curating your kitchen&apos;s essentials with intent.
+          </Paragraph>
+          <div className={dashboardStyles.headerMeta}>
+            <Text className={dashboardStyles.householdName}>{activeHousehold.name}</Text>
+            <Tag color={activeHousehold.role === "owner" ? "green" : "blue"} style={{ margin: 0 }}>
+              {activeHousehold.role.toUpperCase()}
+            </Tag>
+            {members.length > 0 && (
+              <span className={dashboardStyles.headerMetaItem}>
+                <TeamOutlined /> {members.length} member{members.length > 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+        </div>
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={() => router.push(`/open-food-facts?householdId=${activeHousehold.householdId}&householdName=${encodeURIComponent(activeHousehold.name)}`)}
+        >
+          Add Product
+        </Button>
+      </div>
+
+      {loading ? (
+        <Card className={dashboardStyles.emptyCard}><Spin /></Card>
+      ) : (
+        <div className={dashboardStyles.grid}>
+          <div className={dashboardStyles.leftColumn}>
+            <Card className={dashboardStyles.alertCard}>
+              <div className={dashboardStyles.alertTopRow}>
+                <div className={dashboardStyles.alertLabel}>Low stock</div>
+                <div className={dashboardStyles.alertIcon}>!</div>
+              </div>
+              <div className={dashboardStyles.alertContent}>
+                <span className={dashboardStyles.alertValue}>{lowStockCount}</span>
+                <span className={dashboardStyles.alertUnit}>Item{lowStockCount === 1 ? "" : "s"}</span>
+              </div>
+              <div className={dashboardStyles.alertFootnote}>
+                {lowStockCount === 0
+                  ? "All tracked products are comfortably stocked."
+                  : "Products at ≤2 units. Consider restocking soon."}
+              </div>
+            </Card>
+
+            <div className={dashboardStyles.kpiRow}>
+              <Card className={dashboardStyles.kpiCard}>
+                <div className={dashboardStyles.kpiLabel}>Total items</div>
+                <div className={dashboardStyles.kpiValue}>{totalUnits}</div>
+                <div className={dashboardStyles.kpiSub}>
+                  {pantry?.items?.length ?? 0} distinct product{(pantry?.items?.length ?? 0) === 1 ? "" : "s"}
+                </div>
+              </Card>
+              <Card className={dashboardStyles.kpiCardOutline}>
+                <div className={dashboardStyles.kpiLabel}>Calories this week</div>
+                <div className={dashboardStyles.kpiValue}>{Math.round(weeklyCalories)}</div>
+                <div className={dashboardStyles.kpiSub}>
+                  {weeklyLogs.length === 0
+                    ? "No consumption logged yet"
+                    : `${weeklyLogs.length} log${weeklyLogs.length > 1 ? "s" : ""} in last 7 days`}
+                </div>
+              </Card>
+              <Card className={dashboardStyles.kpiCardGreen}>
+                <div className={dashboardStyles.kpiLabel}>Most consumed</div>
+                <div className={dashboardStyles.kpiTitle} title={mostConsumed?.name}>
+                  {mostConsumed ? mostConsumed.name : "No data yet"}
+                </div>
+                <div className={dashboardStyles.kpiSub}>
+                  {mostConsumed ? `${mostConsumed.qty} units / week` : "Record consumption to see trends"}
+                </div>
+              </Card>
+            </div>
+
+            <Card
+              className={dashboardStyles.inventoryCard}
+              title={
+                <div className={dashboardStyles.sectionTitleRow}>
+                  <span>Current Inventory</span>
+                  <Button
+                    type="link"
+                    size="small"
+                    icon={<AppstoreOutlined />}
+                    onClick={() =>
+                      router.push(
+                        `/households/${activeHousehold.householdId}?name=${encodeURIComponent(activeHousehold.name)}`,
+                      )
+                    }
+                  >
+                    View all
+                  </Button>
+                </div>
+              }
+            >
+              {inventoryRows.length === 0 ? (
+                <Text type="secondary">No products in pantry yet.</Text>
+              ) : (
+                <div className={dashboardStyles.inventoryTable}>
+                  <div className={dashboardStyles.inventoryHead}>
+                    <span>Product</span>
+                    <span>Quantity</span>
+                    <span>Category</span>
+                    <span>Status</span>
+                  </div>
+                  {inventoryRows.map((row) => (
+                    <div key={row.id} className={dashboardStyles.inventoryRow}>
+                      <span className={dashboardStyles.productCell} title={row.product}>{row.product}</span>
+                      <span>{row.quantity}</span>
+                      <span className={dashboardStyles.categoryPill}>{row.category}</span>
+                      <span className={row.statusTone === "danger" ? dashboardStyles.statusDanger : dashboardStyles.statusOk}>
+                        {row.status}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Card>
+          </div>
+
+          <div className={dashboardStyles.rightColumn}>
+            <Card
+              className={dashboardStyles.activityCard}
+              title={
+                <div className={dashboardStyles.sectionTitleRow}>
+                  <span>Recent Activity</span>
+                  <Button
+                    type="link"
+                    size="small"
+                    icon={<HistoryOutlined />}
+                    onClick={() =>
+                      router.push(
+                        `/households/${activeHousehold.householdId}/stats?name=${encodeURIComponent(activeHousehold.name)}`,
+                      )
+                    }
+                  >
+                    Full history
+                  </Button>
+                </div>
+              }
+            >
+              {activity.length === 0 ? (
+                <Text type="secondary">No recent activity yet.</Text>
+              ) : (
+                <div className={dashboardStyles.activityList}>
+                  {activity.slice(0, 5).map((entry, index) => {
+                    const actor =
+                      (entry.username && entry.username !== "Unknown user" ? entry.username : null) ??
+                      memberNameById.get(entry.userId) ??
+                      `User #${entry.userId}`;
+                    const isRemoved = entry.productName === REMOVED_ITEM_LABEL;
+                    const avatarText = isRemoved ? "·" : initialsOf(actor);
+                    const avatarTone = isRemoved
+                      ? dashboardStyles.avatarToneMuted
+                      : dashboardStyles[`avatarTone${(index % 4) + 1}` as const];
+                    return (
+                      <div key={entry.logId} className={dashboardStyles.activityItem}>
+                        <div className={`${dashboardStyles.activityAvatar} ${avatarTone}`}>
+                          {avatarText}
+                        </div>
+                        <div className={dashboardStyles.activityBody}>
+                          <div className={dashboardStyles.activityText}>
+                            <span className={dashboardStyles.activityActor}>{actor}</span>
+                            <span className={dashboardStyles.activityVerb}> consumed </span>
+                            <span className={dashboardStyles.activityAmount}>{entry.consumedQuantity}×</span>{" "}
+                            {isRemoved ? (
+                              <span className={dashboardStyles.activityRemoved}>an item no longer in pantry</span>
+                            ) : (
+                              <span className={dashboardStyles.activityProduct}>{entry.productName}</span>
+                            )}
+                          </div>
+                          <div className={dashboardStyles.activityTime}>
+                            {formatAgo(entry.consumedAt)}
+                            {entry.consumedCalories
+                              ? ` · ${Math.round(entry.consumedCalories)} kcal`
+                              : ""}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </Card>
+
+            <Card className={dashboardStyles.tipCard}>
+              <div className={dashboardStyles.tipLabel}>{contextualTip.label}</div>
+              <div className={dashboardStyles.tipText}>{contextualTip.text}</div>
+            </Card>
+          </div>
+        </div>
+      )}
+    </VirtualPantryAppShell>
   );
 };
 
-export default Dashboard;
+export default DashboardPage;


### PR DESCRIPTION
- Fetch household members and map userId -> username (falls back to server-provided username once backend sends it)
- Show actor + product + qty in Recent Activity; render removed pantry rows as 'item no longer in pantry'
- Skip 'Removed item' entries when computing Most Consumed
- Add 'Calories this week' KPI and member count / role in header
- Fix View all / Full history links to reach real pages
- Contextual Kitchen Tip based on low stock / empty pantry / no logs