### PR TITLE
feat(#97): send targetWeight/weeksToGoal to backend; restore form on load

### DIFF
--- a/app/types/healthGoal.ts
+++ b/app/types/healthGoal.ts
@@ -7,6 +7,9 @@ export interface HealthGoal {
   userId: number;
   goalType: GoalType;
   targetRate: number | null;
+  // targetWeight and weeksToGoal are stored so the form can be restored on reload
+  targetWeight: number | null;
+  weeksToGoal: number | null;
   age: number;
   sex: Sex;
   height: number;
@@ -18,7 +21,9 @@ export interface HealthGoal {
 
 export interface HealthGoalPutRequest {
   goalType: GoalType;
-  targetRate?: number | null;
+  // targetWeight and weeksToGoal replace targetRate — the backend derives targetRate from them
+  targetWeight?: number | null;
+  weeksToGoal?: number | null;
   age: number;
   sex: Sex;
   height: number;

--- a/app/users/[id]/health-goal/page.test.tsx
+++ b/app/users/[id]/health-goal/page.test.tsx
@@ -65,6 +65,8 @@ describe("HealthGoalPage", () => {
       userId: 1,
       goalType: "MAINTAIN",
       targetRate: null,
+      targetWeight: null,   // new fields now returned by backend
+      weeksToGoal: null,
       age: 28,
       sex: "FEMALE",
       height: 165,
@@ -102,6 +104,8 @@ describe("HealthGoalPage", () => {
       userId: 1,
       goalType: "LOSE_WEIGHT",
       targetRate: 0.5,
+      targetWeight: 75.0,   // new fields now returned by backend
+      weeksToGoal: 20,
       age: 30,
       sex: "MALE",
       height: 175,

--- a/app/users/[id]/health-goal/page.tsx
+++ b/app/users/[id]/health-goal/page.tsx
@@ -85,7 +85,9 @@ export default function HealthGoalPage() {
           weight: goal.weight,
           activityLevel: goal.activityLevel,
           goalType: goal.goalType,
-          // targetWeight and weeksToGoal are not stored on the backend
+          // Restore loss-specific fields now that they are persisted on the backend
+          targetWeight: goal.targetWeight ?? undefined,
+          weeksToGoal: goal.weeksToGoal ?? undefined,
         });
         setGoalType(goal.goalType);
         setRecommendation(goal.recommendedDailyCalories);
@@ -109,10 +111,7 @@ export default function HealthGoalPage() {
   const handleSave = async (values: FormValues) => {
     setSaving(true);
     try {
-      let targetRate: number | null = null;
-      if (values.goalType === "LOSE_WEIGHT" && values.targetWeight != null && values.weeksToGoal != null) {
-        targetRate = (values.weight - values.targetWeight) / values.weeksToGoal;
-      }
+      // Send targetWeight and weeksToGoal directly — backend derives targetRate
       const body: HealthGoalPutRequest = {
         goalType: values.goalType as HealthGoalPutRequest["goalType"],
         age: values.age,
@@ -120,7 +119,8 @@ export default function HealthGoalPage() {
         height: values.height,
         weight: values.weight,
         activityLevel: values.activityLevel as HealthGoalPutRequest["activityLevel"],
-        targetRate,
+        targetWeight: values.goalType === "LOSE_WEIGHT" ? (values.targetWeight ?? null) : null,
+        weeksToGoal: values.goalType === "LOSE_WEIGHT" ? (values.weeksToGoal ?? null) : null,
       };
       const saved = await api.put<HealthGoal>(`/users/${urlId}/health-goal`, body);
       setRecommendation(saved.recommendedDailyCalories);


### PR DESCRIPTION
## Summary

- Remove client-side `targetRate` computation; backend now derives it from `targetWeight` and `weeksToGoal`
- Send both fields directly in PUT request body
- Restore `targetWeight` and `weeksToGoal` from GET response so the form refills correctly on reload
- Update `HealthGoal` and `HealthGoalPutRequest` types accordingly
- Update `page.test.tsx` mocks to include the new response fields

## Test plan

- [ ] `page.test.tsx` — 5 tests pass
- [ ] `npm run build` — no TypeScript errors
- [ ] Manual: set LOSE_WEIGHT goal → save → reload page → targetWeight and weeksToGoal fields are pre-filled