### PR TITLE
fix: show consumed calories and original add quantity in activity feed

### DIFF
--- a/app/households/[id]/stats/page.tsx
+++ b/app/households/[id]/stats/page.tsx
@@ -88,7 +88,7 @@ function logsToActivity(logs: ConsumptionLogEntry[]): ActivityEntry[] {
     id: `consume-${log.logId}`,
     at: log.consumedAt,
     productName: log.productName,
-    deltaKcal: log.consumedCalories != null ? -log.consumedCalories : null,
+    deltaKcal: log.consumedCalories ?? null,
     quantity: log.consumedQuantity,
     unit: log.consumedUnit,
     type: "CONSUMED",
@@ -121,7 +121,7 @@ function pantryItemsToActivity(items: PantryItem[]): ActivityEntry[] {
       at: item.addedAt,
       productName: item.name,
       deltaKcal: computeItemKcal(item),
-      quantity: item.amount,
+      quantity: item.initialAmount ?? item.amount,
       unit: item.amountUnit,
       type: "ADDED",
     }));
@@ -1034,7 +1034,7 @@ export default function StatsPage() {
                               </div>
                               <span className={`${statsStyles.activityDelta} ${isAdded ? statsStyles.deltaPos : statsStyles.deltaNeg}`}>
                                 {isKnownCalories(a.deltaKcal)
-                                  ? `${isAdded ? "+" : ""}${Math.round(a.deltaKcal).toLocaleString()} kcal`
+                                  ? `${isAdded ? "+" : "-"}${Math.round(a.deltaKcal).toLocaleString()} kcal`
                                   : "—"}
                               </span>
                             </div>

--- a/app/types/pantry.ts
+++ b/app/types/pantry.ts
@@ -17,6 +17,7 @@ export interface PantryItem {
   barcode: string | null;
   name: string;
   amount: number;
+  initialAmount?: number;
   amountUnit: AmountUnit;
   kcalPerPackage?: number | null;
   kcalPer100g?: number | null;


### PR DESCRIPTION
## Summary
- Consumed entries in the activity feed now show calorie values (e.g. `-120 kcal`) instead of always showing `—`. Root cause: `deltaKcal` was stored as a negative number but `isKnownCalories` only accepted `> 0`, so the check always failed.
- "Added" entries now show the original add quantity instead of the current remaining amount. Uses new `initialAmount` field from the server (falls back to `amount` if server is not yet updated).
- Requires server PR: `fix/activity-feed-calorie-and-initial-amount`

## Test plan
- [ ] Add an item (e.g. 1000ml milk), verify activity shows "Added 1000ml milk"
- [ ] Consume a portion (e.g. 200ml), verify activity shows "Consumed 200ml milk" with `-X kcal`
- [ ] Verify "Added 1000ml milk" still shows 1000ml after consumption (not 800ml)