### PR TITLE
feat(#124): add calorie charts to stats page

### DIFF
--- a/app/households/[id]/stats/page.test.tsx
+++ b/app/households/[id]/stats/page.test.tsx
@@ -186,6 +186,8 @@ jest.mock("antd", () => {
   const App = {
     useApp: () => ({ message: messageMock }),
   };
+  // Issue #124 — Divider added to antd imports in stats page
+  const Divider = () => <hr />;
 
   return {
     Button,
@@ -206,8 +208,21 @@ jest.mock("antd", () => {
     Form,
     InputNumber,
     Radio,
+    Divider,
   };
 });
+
+// Issue #124 — mock recharts so chart components render as no-ops in jsdom
+jest.mock("recharts", () => ({
+  BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  ReferenceLine: () => null,
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  Cell: () => null,
+}));
 
 describe("StatsPage", () => {
   beforeEach(() => {

--- a/app/households/[id]/stats/page.tsx
+++ b/app/households/[id]/stats/page.tsx
@@ -7,6 +7,7 @@ import {
   Card,
   Col,
   DatePicker,
+  Divider,
   Empty,
   Form,
   InputNumber,
@@ -22,6 +23,16 @@ import {
   Select,   // Issue #121
 } from "antd";
 import type { TableProps } from "antd";
+// Issue #124 — recharts for calorie charts
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ReferenceLine,
+  Cell,
+} from "recharts";
 import {
   ArrowLeftOutlined,
   EditOutlined,
@@ -510,6 +521,30 @@ export default function StatsPage() {
     return `+${pct}% OVER BUDGET (today)`;
   }, [actualToday, dailyGoal]);
 
+  // Issue #124 — my personal intake today, from the per-user breakdown returned by the backend
+  const myActualToday = useMemo(() => {
+    if (!stats?.myDailyBreakdown?.length) return 0;
+    const row = stats.myDailyBreakdown.find((d) => d.date === todayStr);
+    return row?.caloriesConsumed ?? 0;
+  }, [stats, todayStr]);
+
+  const myPersonalGoal = personalGoal?.recommendedDailyCalories ?? null;
+  // Issue #124 — fixed 7-day slices for the two daily charts
+  const myLast7Days = useMemo(() => (stats?.myDailyBreakdown ?? []).slice(-7), [stats]);
+  const householdLast7Days = useMemo(() => (stats?.dailyBreakdown ?? []).slice(-7), [stats]);
+
+  const myTodayVsGoalPercent = useMemo(() => {
+    if (!myPersonalGoal || myPersonalGoal <= 0) return 0;
+    return (myActualToday / myPersonalGoal) * 100;
+  }, [myActualToday, myPersonalGoal]);
+
+  const myTodayOverLabel = useMemo(() => {
+    if (!myPersonalGoal || myPersonalGoal <= 0) return null;
+    if (myActualToday <= myPersonalGoal) return null;
+    const pct = ((myActualToday / myPersonalGoal) * 100 - 100).toFixed(0);
+    return `+${pct}% over your personal goal (today)`;
+  }, [myActualToday, myPersonalGoal]);
+
   const openBudgetModal = () => {
     const initial = dailyGoal ?? 2200;
     budgetForm.setFieldsValue({ dailyCalorieTarget: initial });
@@ -882,74 +917,94 @@ export default function StatsPage() {
                   }
                   variant="borderless"
                 >
+                  {/* Issue #124 — two clearly labelled progress rows so users know what each one measures */}
                   <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+
+                    {/* Row 1: household total today vs household daily target (set by admin) */}
                     <div>
-                      <Text style={{ color: MUTED }}>Your recommendation</Text>
-                      <div>
-                        {personalGoal ? (
-                          <Text strong style={{ fontSize: 16, color: FOREST }}>
-                            {Math.round(personalGoal.recommendedDailyCalories).toLocaleString()} kcal
-                          </Text>
-                        ) : (
-                          <Text style={{ color: MUTED }}>
-                            Not set ·{" "}
-                            {userId && (
-                              <Button
-                                type="link"
-                                onClick={() => router.push(`/users/${userId}/health-goal`)}
-                                style={{ color: FOREST, padding: 0, height: "auto" }}
-                              >
-                                Set goal →
-                              </Button>
-                            )}
-                          </Text>
-                        )}
-                      </div>
-                    </div>
-                    <div>
-                      <Text style={{ color: MUTED }}>Daily goal</Text>
-                      <div>
-                        <Text strong style={{ fontSize: 16, color: "#1b2a1b" }}>
-                          {dailyGoal !== null ? formatKcal(dailyGoal) : "Not set"}
-                        </Text>
-                      </div>
-                    </div>
-                    <div>
-                      <Text style={{ color: MUTED }}>Actual today</Text>
-                      <div>
-                        <Text
-                          strong
-                          style={{
-                            fontSize: 16,
-                            color: todayVsGoalPercent > 100 ? DANGER : FOREST,
-                          }}
-                        >
+                      <Text style={{ color: MUTED, fontSize: 12 }}>
+                        🏠 Household total today
+                        <Text style={{ color: MUTED, fontSize: 11, fontWeight: 400 }}> — all members combined, vs the household daily target set by admin</Text>
+                      </Text>
+                      <div style={{ display: "flex", alignItems: "baseline", gap: 8, margin: "4px 0" }}>
+                        <Text strong style={{ fontSize: 15, color: todayVsGoalPercent > 100 ? DANGER : FOREST }}>
                           {stats ? formatKcal(actualToday) : "—"}
                         </Text>
+                        {dailyGoal !== null && (
+                          <Text style={{ color: MUTED, fontSize: 12 }}>/ {formatKcal(dailyGoal)} target</Text>
+                        )}
                       </div>
+                      {dailyGoal !== null && dailyGoal > 0 ? (
+                        <>
+                          <Progress
+                            percent={Math.min(Math.round(todayVsGoalPercent), 100)}
+                            status={todayVsGoalPercent > 100 ? "exception" : "active"}
+                            strokeColor={todayVsGoalPercent > 100 ? DANGER : FOREST}
+                            railColor="#e8efe4"
+                            showInfo
+                            format={(p) => `${p ?? 0}%`}
+                          />
+                          {todayOverLabel && (
+                            <Tag color="error" icon={<WarningOutlined />} style={{ marginTop: 4 }}>
+                              {todayOverLabel}
+                            </Tag>
+                          )}
+                        </>
+                      ) : (
+                        <Text style={{ color: MUTED, fontSize: 12 }}>
+                          No household target set —{" "}
+                          <Button type="link" onClick={openBudgetModal} style={{ color: FOREST, padding: 0, height: "auto", fontSize: 12 }}>
+                            Set target →
+                          </Button>
+                        </Text>
+                      )}
                     </div>
 
-                    {dailyGoal !== null && dailyGoal > 0 ? (
-                      <>
-                        <Progress
-                          percent={Math.min(Math.round(todayVsGoalPercent), 100)}
-                          status={todayVsGoalPercent > 100 ? "exception" : "active"}
-                          strokeColor={todayVsGoalPercent > 100 ? DANGER : FOREST}
-                          railColor="#e8efe4"
-                          showInfo
-                          format={(p) => `${p ?? 0}% of daily goal (today)`}
-                        />
-                        {todayOverLabel ? (
-                          <Tag color="error" icon={<WarningOutlined />}>
-                            {todayOverLabel}
-                          </Tag>
-                        ) : null}
-                      </>
-                    ) : (
-                      <Text style={{ color: MUTED }}>
-                        Set a daily calorie target to enable comparisons.
+                    <Divider style={{ margin: "4px 0" }} />
+
+                    {/* Row 2: my personal intake today vs my personal health goal */}
+                    <div>
+                      <Text style={{ color: MUTED, fontSize: 12 }}>
+                        👤 Your intake today
+                        <Text style={{ color: MUTED, fontSize: 11, fontWeight: 400 }}> — your consumption only, vs your personal health goal</Text>
                       </Text>
-                    )}
+                      {myPersonalGoal ? (
+                        <>
+                          <div style={{ display: "flex", alignItems: "baseline", gap: 8, margin: "4px 0" }}>
+                            <Text strong style={{ fontSize: 15, color: myTodayVsGoalPercent > 100 ? DANGER : FOREST }}>
+                              {stats ? formatKcal(myActualToday) : "—"}
+                            </Text>
+                            <Text style={{ color: MUTED, fontSize: 12 }}>/ {formatKcal(myPersonalGoal)} personal goal</Text>
+                          </div>
+                          <Progress
+                            percent={Math.min(Math.round(myTodayVsGoalPercent), 100)}
+                            status={myTodayVsGoalPercent > 100 ? "exception" : "active"}
+                            strokeColor={myTodayVsGoalPercent > 100 ? DANGER : FOREST}
+                            railColor="#e8efe4"
+                            showInfo
+                            format={(p) => `${p ?? 0}%`}
+                          />
+                          {myTodayOverLabel && (
+                            <Tag color="error" icon={<WarningOutlined />} style={{ marginTop: 4 }}>
+                              {myTodayOverLabel}
+                            </Tag>
+                          )}
+                        </>
+                      ) : (
+                        <Text style={{ color: MUTED, fontSize: 12 }}>
+                          No personal health goal set —{" "}
+                          {userId && (
+                            <Button
+                              type="link"
+                              onClick={() => router.push(`/users/${userId}/health-goal`)}
+                              style={{ color: FOREST, padding: 0, height: "auto", fontSize: 12 }}
+                            >
+                              Set goal →
+                            </Button>
+                          )}
+                        </Text>
+                      )}
+                    </div>
 
                     {stats?.comparisonToBudget ? (
                       <div>
@@ -1061,50 +1116,139 @@ export default function StatsPage() {
               </Col>
             </Row>
 
-            {stats ? (
-              <Card title="Daily breakdown" className={statsStyles.breakdownCard}>
-                <Table
-                  rowKey="date"
-                  pagination={false}
-                  size="small"
-                  dataSource={stats.dailyBreakdown}
-                  columns={[
-                    { title: "Date", dataIndex: "date", key: "date" },
-                    {
-                      title: "Calories consumed",
-                      dataIndex: "caloriesConsumed",
-                      key: "caloriesConsumed",
-                      render: (value: number) => value.toFixed(1),
-                    },
-                  ]}
-                />
+            {/* Issue #124 — Chart 1: my personal daily calorie intake, last 7 days.
+                Always shown; goal line and color coding only appear when personal goal is set. */}
+            {myLast7Days.length > 0 && (
+              <Card
+                title={<span style={{ fontSize: 16, fontWeight: 700, color: "#1f2d1f" }}>My daily calorie intake</span>}
+                style={{ borderRadius: 16, borderColor: "#d9e2cf" }}
+              >
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Your personal consumption · last 7 days
+                </Typography.Text>
+                {myPersonalGoal ? (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, margin: "6px 0 12px" }}>
+                    <svg width="24" height="10"><line x1="0" y1="5" x2="24" y2="5" stroke={FOREST} strokeWidth="2" strokeDasharray="5 3" /></svg>
+                    <Typography.Text style={{ fontSize: 11, color: MUTED }}>
+                      Your personal health goal · {Math.round(myPersonalGoal).toLocaleString()} kcal/day (set in your profile)
+                    </Typography.Text>
+                  </div>
+                ) : (
+                  <div style={{ margin: "6px 0 12px" }}>
+                    <Typography.Text style={{ fontSize: 11, color: MUTED }}>
+                      No personal goal set —{" "}
+                      {userId && (
+                        <Button type="link" onClick={() => router.push(`/users/${userId}/health-goal`)} style={{ color: FOREST, padding: 0, height: "auto", fontSize: 11 }}>
+                          Set goal to enable comparison →
+                        </Button>
+                      )}
+                    </Typography.Text>
+                  </div>
+                )}
+                <div style={{ overflowX: "auto" }}>
+                  <BarChart
+                    width={Math.max(myLast7Days.length * 100 + 64, 300)}
+                    height={220}
+                    data={myLast7Days}
+                    margin={{ top: 10, right: 40, left: 0, bottom: 0 }}
+                    barCategoryGap="35%"
+                  >
+                    <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(d: string) => d.slice(5)} />
+                    <YAxis tick={{ fontSize: 11 }} tickFormatter={(v: number) => `${v}`} width={48} />
+                    <Tooltip formatter={(v: unknown) => `${Math.round(Number(v))} kcal`} labelFormatter={(l: unknown) => `Date: ${String(l)}`} />
+                    {myPersonalGoal && (
+                      <ReferenceLine y={myPersonalGoal} stroke={FOREST} strokeDasharray="5 3" strokeWidth={2} label={{ value: "goal", position: "insideTopRight", fontSize: 10, fill: FOREST }} />
+                    )}
+                    <Bar dataKey="caloriesConsumed" maxBarSize={56} radius={[4, 4, 0, 0]}>
+                      {myLast7Days.map((entry) => (
+                        <Cell key={entry.date} fill={myPersonalGoal && entry.caloriesConsumed > myPersonalGoal ? DANGER : "#7cb87e"} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </div>
+                {myPersonalGoal && (
+                  <div style={{ display: "flex", gap: 16, marginTop: 8, fontSize: 11, color: MUTED }}>
+                    <span><span style={{ color: DANGER }}>■</span> Exceeds your personal goal</span>
+                    <span><span style={{ color: "#7cb87e" }}>■</span> Within your personal goal</span>
+                  </div>
+                )}
               </Card>
-            ) : null}
-            {/* Issue #121 — per-member daily average calorie breakdown */}
+            )}
+
+            {/* Issue #124 — Chart 3: household daily total, last 7 days with target reference line */}
+            {householdLast7Days.length > 0 && (
+              <Card
+                title={<span style={{ fontSize: 16, fontWeight: 700, color: "#1f2d1f" }}>Household daily calorie consumption</span>}
+                style={{ borderRadius: 16, borderColor: "#d9e2cf" }}
+              >
+                <Typography.Text type="secondary" style={{ fontSize: 12, display: "block", marginBottom: dailyGoal ? 4 : 12 }}>
+                  Total kcal consumed by all members combined · last 7 days
+                </Typography.Text>
+                {dailyGoal && (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 12 }}>
+                    <svg width="24" height="10"><line x1="0" y1="5" x2="24" y2="5" stroke={DANGER} strokeWidth="2" strokeDasharray="5 3" /></svg>
+                    <Typography.Text style={{ fontSize: 11, color: MUTED }}>
+                      Household daily target · {Math.round(dailyGoal).toLocaleString()} kcal/day (set by admin)
+                    </Typography.Text>
+                  </div>
+                )}
+                <div style={{ overflowX: "auto" }}>
+                  <BarChart
+                    width={Math.max(householdLast7Days.length * 100 + 64, 300)}
+                    height={220}
+                    data={householdLast7Days}
+                    margin={{ top: 10, right: 40, left: 0, bottom: 0 }}
+                    barCategoryGap="35%"
+                  >
+                    <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(d: string) => d.slice(5)} />
+                    <YAxis tick={{ fontSize: 11 }} tickFormatter={(v: number) => `${v}`} width={48} />
+                    <Tooltip formatter={(v: unknown) => `${Math.round(Number(v))} kcal`} labelFormatter={(l: unknown) => `Date: ${String(l)}`} />
+                    {dailyGoal && (
+                      <ReferenceLine y={dailyGoal} stroke={DANGER} strokeDasharray="5 3" strokeWidth={2} label={{ value: "target", position: "insideTopRight", fontSize: 10, fill: DANGER }} />
+                    )}
+                    <Bar dataKey="caloriesConsumed" maxBarSize={56} radius={[4, 4, 0, 0]}>
+                      {householdLast7Days.map((entry) => (
+                        <Cell key={entry.date} fill={dailyGoal && entry.caloriesConsumed > dailyGoal ? DANGER : FOREST} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </div>
+                {dailyGoal && (
+                  <div style={{ display: "flex", gap: 16, marginTop: 8, fontSize: 11, color: MUTED }}>
+                    <span><span style={{ color: DANGER }}>■</span> Exceeds household target</span>
+                    <span><span style={{ color: FOREST }}>■</span> Within target</span>
+                  </div>
+                )}
+              </Card>
+            )}
+
+            {/* Issue #124 — Chart 2: member average daily intake, placed last; horizontal scroll for large households */}
             {stats?.memberBreakdown && stats.memberBreakdown.length > 0 && (
               <Card
-                title={<span style={{ fontSize: 20, fontWeight: 700, color: "#1f2d1f" }}>Calorie breakdown by member</span>}
-                style={{ borderRadius: 16, borderColor: "#d9e2cf", background: "#ffffff" }}
-                styles={{ body: { padding: 24 } }}
+                title={<span style={{ fontSize: 16, fontWeight: 700, color: "#1f2d1f" }}>Average daily intake per member</span>}
+                style={{ borderRadius: 16, borderColor: "#d9e2cf" }}
               >
-                <Table
-                  rowKey="userId"
-                  dataSource={stats.memberBreakdown}
-                  pagination={false}
-                  columns={[
-                    {
-                      title: "Member",
-                      dataIndex: "username",
-                      key: "username",
-                    },
-                    {
-                      title: "Daily average",
-                      dataIndex: "averageDailyCalories",
-                      key: "averageDailyCalories",
-                      render: (v: number) => `${Math.round(v).toLocaleString()} kcal/day`,
-                    },
-                  ]}
-                />
+                <Typography.Text type="secondary" style={{ fontSize: 12, display: "block", marginBottom: 12 }}>
+                  Each member&apos;s average kcal consumed per day during the selected period
+                </Typography.Text>
+                <div style={{ overflowX: "auto" }}>
+                  <BarChart
+                    width={Math.max(stats.memberBreakdown.length * 120, 400)}
+                    height={220}
+                    data={stats.memberBreakdown.map((m) => ({
+                      ...m,
+                      label: String(m.userId) === userId ? "You" : m.username,
+                    }))}
+                    margin={{ top: 10, right: 16, left: 0, bottom: 0 }}
+                    barCategoryGap="35%"
+                  >
+                    <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                    <YAxis tick={{ fontSize: 11 }} tickFormatter={(v: number) => `${v}`} width={48} />
+                    <Tooltip formatter={(v: unknown) => `${Math.round(Number(v))} kcal/day`} />
+                    <Bar dataKey="averageDailyCalories" fill={FOREST} maxBarSize={56} radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </div>
+                <Typography.Text style={{ fontSize: 11, color: MUTED }}>kcal / day average</Typography.Text>
               </Card>
             )}
           </>

--- a/app/households/[id]/stats/page.tsx
+++ b/app/households/[id]/stats/page.tsx
@@ -521,9 +521,9 @@ export default function StatsPage() {
     return `+${pct}% OVER BUDGET (today)`;
   }, [actualToday, dailyGoal]);
 
-  // Issue #124 — my personal intake today, from the per-user breakdown returned by the backend
+  // Issue #124 — null when the field is absent (old API), 0 when present but nothing consumed today
   const myActualToday = useMemo(() => {
-    if (!stats?.myDailyBreakdown?.length) return 0;
+    if (!stats?.myDailyBreakdown) return null;
     const row = stats.myDailyBreakdown.find((d) => d.date === todayStr);
     return row?.caloriesConsumed ?? 0;
   }, [stats, todayStr]);
@@ -534,12 +534,12 @@ export default function StatsPage() {
   const householdLast7Days = useMemo(() => (stats?.dailyBreakdown ?? []).slice(-7), [stats]);
 
   const myTodayVsGoalPercent = useMemo(() => {
-    if (!myPersonalGoal || myPersonalGoal <= 0) return 0;
+    if (myActualToday === null || !myPersonalGoal || myPersonalGoal <= 0) return 0;
     return (myActualToday / myPersonalGoal) * 100;
   }, [myActualToday, myPersonalGoal]);
 
   const myTodayOverLabel = useMemo(() => {
-    if (!myPersonalGoal || myPersonalGoal <= 0) return null;
+    if (myActualToday === null || !myPersonalGoal || myPersonalGoal <= 0) return null;
     if (myActualToday <= myPersonalGoal) return null;
     const pct = ((myActualToday / myPersonalGoal) * 100 - 100).toFixed(0);
     return `+${pct}% over your personal goal (today)`;
@@ -952,10 +952,15 @@ export default function StatsPage() {
                         </>
                       ) : (
                         <Text style={{ color: MUTED, fontSize: 12 }}>
-                          No household target set —{" "}
-                          <Button type="link" onClick={openBudgetModal} style={{ color: FOREST, padding: 0, height: "auto", fontSize: 12 }}>
-                            Set target →
-                          </Button>
+                          No household target set
+                          {/* Issue #124 — only owners can set the household target */}
+                          {isOwner && (
+                            <> —{" "}
+                              <Button type="link" onClick={openBudgetModal} style={{ color: FOREST, padding: 0, height: "auto", fontSize: 12 }}>
+                                Set target →
+                              </Button>
+                            </>
+                          )}
                         </Text>
                       )}
                     </div>
@@ -972,7 +977,7 @@ export default function StatsPage() {
                         <>
                           <div style={{ display: "flex", alignItems: "baseline", gap: 8, margin: "4px 0" }}>
                             <Text strong style={{ fontSize: 15, color: myTodayVsGoalPercent > 100 ? DANGER : FOREST }}>
-                              {stats ? formatKcal(myActualToday) : "—"}
+                              {stats && myActualToday !== null ? formatKcal(myActualToday) : "—"}
                             </Text>
                             <Text style={{ color: MUTED, fontSize: 12 }}>/ {formatKcal(myPersonalGoal)} personal goal</Text>
                           </div>

--- a/app/types/stats.ts
+++ b/app/types/stats.ts
@@ -26,4 +26,5 @@ export interface HouseholdStats {
   dailyBreakdown: DailyBreakdownEntry[];
   comparisonToBudget: BudgetComparison | null;
   memberBreakdown?: MemberCalorieEntry[];  // Issue #121
+  myDailyBreakdown?: DailyBreakdownEntry[];  // Issue #124 — requesting user's per-day data
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "process": "^0.11.10",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "recharts": "^3.8.1",
         "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
@@ -3086,6 +3087,42 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3126,6 +3163,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@stomp/stompjs": {
       "version": "7.3.0",
@@ -3307,6 +3356,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3420,7 +3532,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3455,6 +3567,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -4942,6 +5060,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -5046,6 +5285,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -5416,6 +5661,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5878,6 +6133,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "2.0.2",
@@ -6634,6 +6895,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6721,6 +6992,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -9451,6 +9731,59 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -9463,6 +9796,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9523,6 +9871,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {
@@ -10497,6 +10851,12 @@
         "node": ">=12.22"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -10976,6 +11336,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -10989,6 +11358,28 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "process": "^0.11.10",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "recharts": "^3.8.1",
     "sockjs-client": "^1.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Replace daily breakdown table and member breakdown table with 3 interactive bar charts
- Split today's progress bar into two clearly labelled rows (household vs personal)
- Install `recharts`

## Charts

**Chart 1 — My daily calorie intake** (last 7 days)
Personal goal reference line shown if health goal is set; bars colored red/green accordingly. Always visible regardless of goal.

**Chart 2 — Household daily calorie consumption** (last 7 days)
Household admin target shown as dashed reference line; bars colored red when exceeding target.

**Chart 3 — Average daily intake per member** (selected period)
All members visible; horizontal scroll for large households.

## Backend change (separate PR in server repo)
Added `myDailyBreakdown` field to `HouseholdStatsGetDTO` — per-day breakdown filtered by the requesting user.

Closes #124